### PR TITLE
[CAZ-1153] Add back button to LAs page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ end
 group :test do
   gem 'capybara'
   gem 'cucumber-rails', require: false
+  # Used to set session values in cucumber tests
+  gem 'rack_session_access'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack_session_access (0.2.0)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
     rails (6.0.0)
       actioncable (= 6.0.0)
       actionmailbox (= 6.0.0)
@@ -336,6 +339,7 @@ DEPENDENCIES
   listen
   logstash-logger
   puma
+  rack_session_access
   rails (~> 6.0.0)
   rails-controller-testing
   rspec-rails

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -20,6 +20,6 @@ class LocalAuthoritiesController < ApplicationController
   # * +vrn+ - lack of VRN redirects to {enter_details}[rdoc-ref:VehiclesController.enter_details]
   #
   def index
-    # renders static page
+    @return_path = request.referer || enter_details_vehicles_path
   end
 end

--- a/app/views/local_authorities/index.html.haml
+++ b/app/views/local_authorities/index.html.haml
@@ -1,4 +1,4 @@
--#= link_to 'Back', incorrect_details_vehicles_path, method: :get, class: 'govuk-back-link'
+= link_to 'Back', @return_path, class: 'govuk-back-link'
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -15,7 +15,7 @@
 
       .govuk-radios__item
         %input#city-1.govuk-radios__input{name: 'city',
-                                                type: 'radio',
-                                                value: 'Birmingham'}
+                                          type: 'radio',
+                                          value: 'Birmingham'}
         %label.govuk-label.govuk-radios__label{for: 'city-1'}
           Birmingham

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,8 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # https://github.com/railsware/rack_session_access
+  # Used to add eg VRN value to session in cucumber tests
+  config.middleware.use RackSessionAccess::Middleware
 end

--- a/features/local_authorities.feature
+++ b/features/local_authorities.feature
@@ -1,0 +1,35 @@
+Feature: Local Authorities
+  In order to pay the charge in the right place
+  As a user
+  I want to be able to select right local authority
+
+  Scenario: User wants to return with right vehicle data for vehicle registered in the UK
+    Given I am on the vehicles details page
+    Then I choose that the details are correct
+      And I press the Confirm
+    Then I should be on the local authorities page
+    Then I press "Back" link
+      And I should be on the vehicle details page
+
+  Scenario: User wants to return with wrong vehicle data for vehicle registered in the UK
+    Given I am on the vehicles details page
+    Then I choose that the details are incorrect
+      And I press the Confirm
+    Then I should be on the incorrect details page
+      And I press the Continue
+    Then I should be on the local authorities page
+    Then I press "Back" link
+      And I should be on the incorrect details page
+
+  Scenario: User wants to return with vehicle registered not in the UK
+    Given I am on the choose type page
+    Then I choose Car type
+      And I press the Confirm
+    Then I should be on the local authorities page
+    Then I press "Back" link
+      And I should be on the choose type page
+
+  Scenario: User wants to return without the previous page
+    Given I am on the the local authorities page
+    Then I press "Back" link
+      And I should be on the enter details page

--- a/features/refunds.feature
+++ b/features/refunds.feature
@@ -1,0 +1,11 @@
+Feature: Refund
+  In order to get a refund
+  As a user
+  I want to be able to refund rules
+
+  Scenario: User wants to to know in what scenarios he can claim a refund
+    Given I am on the home page
+    Then I press 'Can I claim a refund?' link
+      And I should see "Can I claim a refund?"
+    Then I press the Continue
+      And I should see "Claim a refund"

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
+# content expectations
+
 Then('I should see {string} title') do |string|
   expect(page).to have_title(string)
 end
 
-Then('I should see the Vehicle page') do
-  expect(page).to have_current_path(enter_details_vehicles_path)
+Then('I should see {string}') do |string|
+  expect(page).to have_content(string)
 end
 
-def vrn
-  'CU57ABC'
-end
+# links interactions
 
 Then('I press {string} link') do |string|
   click_link string
+end
+
+Then('I press the Continue') do
+  click_on 'Continue'
+end
+
+Then('I press the Confirm') do
+  click_button 'Confirm'
 end

--- a/features/step_definitions/local_authorities_steps.rb
+++ b/features/step_definitions/local_authorities_steps.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Given('I am on the the local authorities page') do
+  add_vrn_to_session
+  visit local_authorities_path
+end

--- a/features/step_definitions/non_uk_vehicles_steps.rb
+++ b/features/step_definitions/non_uk_vehicles_steps.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Given('I am on the choose type page') do
+  add_vrn_to_session
+  visit choose_type_non_uk_vehicles_path
+end
+
+Then('I choose Car type') do
+  choose('Car')
+end

--- a/features/step_definitions/path_expectations.rb
+++ b/features/step_definitions/path_expectations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+def expect_path(path)
+  expect(page).to have_current_path(path)
+end
+
+Then('I should be on the enter details page') do
+  expect_path(enter_details_vehicles_path)
+end
+
+Then('I should be on the vehicle details page') do
+  expect_path(details_vehicles_path)
+end
+
+Then('I should be on the incorrect details page') do
+  expect_path(incorrect_details_vehicles_path)
+end
+
+Then('I should be on the choose type page') do
+  expect_path(choose_type_non_uk_vehicles_path)
+end
+
+Then('I should be on the non UK page') do
+  expect_path(non_uk_vehicles_path)
+end
+
+Then('I should be on the local authorities page') do
+  expect_path(local_authorities_path)
+end

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+Given('I am on the vehicles details page') do
+  add_vrn_to_session
+  visit details_vehicles_path
+end
+
 Then("I enter a vehicle's registration and choose UK") do
   fill_in('vrn', with: vrn)
   choose('UK')
@@ -8,18 +13,6 @@ end
 Then("I enter a vehicle's registration and choose Non-UK") do
   fill_in('vrn', with: vrn)
   choose('Non-UK')
-end
-
-Then('I press the Continue') do
-  click_on 'Continue'
-end
-
-Then('I press the Confirm') do
-  click_button 'Confirm'
-end
-
-And('I am on the non UK page') do
-  expect(page).to have_current_path(non_uk_vehicles_path)
 end
 
 And('I choose I confirm registration') do
@@ -39,6 +32,6 @@ Then('I choose that the details are incorrect') do
   choose('No')
 end
 
-And('I choose Car type') do
-  choose('Car')
+Then('I choose that the details are correct') do
+  choose('Yes')
 end

--- a/features/step_definitions/welcome_steps.rb
+++ b/features/step_definitions/welcome_steps.rb
@@ -7,7 +7,3 @@ end
 Then('I press the Start now button') do
   click_link 'Start now'
 end
-
-Then('I should see {string}') do |string|
-  expect(page).to have_content(string)
-end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,7 @@
 # files.
 
 require 'cucumber/rails'
+require 'rack_session_access/capybara'
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any

--- a/features/support/session_helper.rb
+++ b/features/support/session_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SessionHelper
+  def add_vrn_to_session
+    page.set_rack_session(vrn: vrn)
+  end
+
+  def vrn
+    'CU57ABC'
+  end
+end
+
+World(SessionHelper)

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -8,7 +8,7 @@ Feature: Vehicles
     Given I am on the home page
     Then I should see "Start now"
       And I press the Start now button
-    Then I should see the Vehicle page
+    Then I should be on the enter details page
       And I should see "Pay a Clean Air Zone charge" title
       And I should see "Vehicle registration details"
     Then I enter a only vehicle's registration
@@ -51,7 +51,7 @@ Feature: Vehicles
     Then I should see "Your vehicle is not UK-Registered"
       And I press the Continue
     Then I should see "Confirm that the registration number is correct"
-      And I am on the non UK page
+      And I should be on the non UK page
     Then I choose I confirm registration
       And I press the Continue
     Then I should see "What is your vehicle?"
@@ -61,9 +61,4 @@ Feature: Vehicles
       And I press the Confirm
     Then I should see "Which Clean Air Zone do you need to pay for?"
 
-  Scenario: User wants to to know in what scenarios he can claim a refund
-    Given I am on the home page
-    Then I press 'Can I claim a refund?' link
-      And I should see "Can I claim a refund?"
-    Then I press the Continue
-      And I should see "Claim a refund"
+


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1153

## Description
<!--- Describe your changes in detail -->
I used `request.referer` to determine the previous path.
Also, I refactored feature tests and added gem for hijacking session in cucumber test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the choosing LA page by 3 ways:
 - Choose the UK as registration country, confirm details
 - Choose the UK as registration country, do NOT confirm details, continue on incorrect details page
 - Choose non UK as registration country, select some type of vehicle

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
