### PR TITLE
[NT] Fix error position for choose type page

### DIFF
--- a/app/views/non_uk_vehicles/choose_type.html.haml
+++ b/app/views/non_uk_vehicles/choose_type.html.haml
@@ -6,15 +6,15 @@
         .govuk-form-group{class: ('govuk-form-group--error' if alert)}
           %fieldset.govuk-fieldset
             %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
-              - if alert
-                %span#caz-select-error.govuk-error-message
-                  %span.govuk-visually-hidden Error:
-                  Tell us what type of vehicle you want to pay for
               %h1.govuk-fieldset__heading
                 What is your vehicle?
             %p
               Since we are not able to find your vehicle's details, you'll need to tell us what type of
               vehicle you want to pay for.
+            - if alert
+              %span#caz-select-error.govuk-error-message
+                %span.govuk-visually-hidden Error:
+                Tell us what type of vehicle you want to pay for
             .govuk-radios
               .govuk-radios__item
                 %input#vehicle-type.govuk-radios__input{name: 'vehicle-type', type: 'radio', value: 'bus'}

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -85,7 +85,7 @@
             %li
               = link_to 'Am I exempt?', nil, target: '_blank', class: 'govuk-link'
             %li
-              = link_to 'Can I claim a refund?', scenarios_refunds_path, target: '_blank', class: 'govuk-link'
+              = link_to 'Can I claim a refund?', scenarios_refunds_path, class: 'govuk-link'
             %li
               = link_to 'Create Fleet Account', nil, target: '_blank', class: 'govuk-link'
             %li


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix error position for choose type page.
Also remove opening a new tab for refund link.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![fix_error](https://user-images.githubusercontent.com/24584219/66167885-cab79a80-e63b-11e9-94ee-4e25852b91a4.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to a issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
