### PR TITLE
[CAZ-1283] Removed Taxi/PHV option from non_uk vehicle form

### DIFF
--- a/app/views/non_uk_vehicles/choose_type.html.haml
+++ b/app/views/non_uk_vehicles/choose_type.html.haml
@@ -41,11 +41,7 @@
                 %label.govuk-label.govuk-radios__label{for: 'vehicle-type-6'}
                   Car
               .govuk-radios__item
-                %input#vehicle-type-7.govuk-radios__input{name: 'vehicle-type', type: 'radio', value: 'taxi'}
+                %input#vehicle-type-7.govuk-radios__input{name: 'vehicle-type', type: 'radio', value: 'motorcycle'}
                 %label.govuk-label.govuk-radios__label{for: 'vehicle-type-7'}
-                  Taxi/PHV
-              .govuk-radios__item
-                %input#vehicle-type-8.govuk-radios__input{name: 'vehicle-type', type: 'radio', value: 'motorcycle'}
-                %label.govuk-label.govuk-radios__label{for: 'vehicle-type-8'}
                   Motorcycle
         = submit_tag 'Confirm', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,73 +3,11 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "3726fe31c845c8e91c2756ad75d597f5f2a795953524e4affc10ce2b3dbd0353",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/charges/daily_charge.html.haml",
-      "line": 51,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"here\", ComplianceDetails.new(vrn, session[:la]).exemption_or_discount_url, :target => \"_blank\", :id => \"exemption-link\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "ChargesController",
-          "method": "daily_charge",
-          "line": 61,
-          "file": "app/controllers/charges_controller.rb",
-          "rendered": {
-            "name": "charges/daily_charge",
-            "file": "app/views/charges/daily_charge.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "charges/daily_charge"
-      },
-      "user_input": "ComplianceDetails.new(vrn, session[:la]).exemption_or_discount_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "85baa34e85de3e48a2d894913ba0c29ceef5c13f4033e00a667acd7afd6b754f",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/charges/daily_charge.html.haml",
-      "line": 51,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"here\", ComplianceDetails.new(vrn, vehicle_details(\"la\")).exemption_or_discount_url, :target => \"_blank\", :id => \"exemption-link\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "ChargesController",
-          "method": "daily_charge",
-          "line": 78,
-          "file": "app/controllers/charges_controller.rb",
-          "rendered": {
-            "name": "charges/daily_charge",
-            "file": "app/views/charges/daily_charge.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "charges/daily_charge"
-      },
-      "user_input": "ComplianceDetails.new(vrn, vehicle_details(\"la\")).exemption_or_discount_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
       "fingerprint": "9eacb58fec2752b8207867640cdad94177e3c98fe60805d64c2aae9a6b8b6729",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/charges/daily_charge.html.haml",
-      "line": 55,
+      "line": 56,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"here\", ComplianceDetails.new(session[:vehicle_details]).exemption_or_discount_url, :target => \"_blank\", :id => \"exemption-link\")",
       "render_path": [
@@ -92,39 +30,8 @@
       "user_input": "ComplianceDetails.new(session[:vehicle_details]).exemption_or_discount_url",
       "confidence": "Weak",
       "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "a2a00881010efcb51ef927ee4862c30683ff968033bbab6756b860a1c6c5f5bc",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/charges/daily_charge.html.haml",
-      "line": 51,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"here\", ComplianceDetails.new(vrn, session.dig(:vehicle_details, \"la\")).exemption_or_discount_url, :target => \"_blank\", :id => \"exemption-link\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "ChargesController",
-          "method": "daily_charge",
-          "line": 78,
-          "file": "app/controllers/charges_controller.rb",
-          "rendered": {
-            "name": "charges/daily_charge",
-            "file": "app/views/charges/daily_charge.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "charges/daily_charge"
-      },
-      "user_input": "ComplianceDetails.new(vrn, session.dig(:vehicle_details, \"la\")).exemption_or_discount_url",
-      "confidence": "Weak",
-      "note": ""
     }
   ],
-  "updated": "2019-10-22 09:21:20 +0200",
-  "brakeman_version": "4.7.0"
+  "updated": "2019-10-22 10:05:43 +0200",
+  "brakeman_version": "4.6.1"
 }


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't need the Taxi/PHV option for non UK vehicles in the form.
https://eaflood.atlassian.net/browse/CAZ-1283
## Description
<!--- Describe your changes in detail -->
Removed option from select. 

## How Has This Been Tested?
I tried to load the form for the non UK car.
![image](https://user-images.githubusercontent.com/998642/67240119-1ac29980-f451-11e9-8517-26f04ed59d87.png)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
