### PR TITLE
[CAZ-1343] Fix link on successful payment page

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -70,7 +70,7 @@ class PaymentsController < ApplicationController
     @la_name = vehicle_details('la_name')
     @dates = vehicle_details('dates')
     @total_charge = vehicle_details('total_charge')
-    session[:vehicle_details] = nil
+    clear_payment_in_session
   end
 
   ##
@@ -84,7 +84,7 @@ class PaymentsController < ApplicationController
   #
   def failure
     @payment_id = vehicle_details('payment_id')
-    session[:vehicle_details] = nil
+    clear_payment_in_session
   end
 
   private
@@ -108,5 +108,10 @@ class PaymentsController < ApplicationController
 
     Rails.logger.warn 'Payment id is missing'
     redirect_to enter_details_vehicles_path
+  end
+
+  def clear_payment_in_session
+    payment_keys = %w[la la_name daily_charge dates total_charge payment_id user_email]
+    session[:vehicle_details].except!(*payment_keys)
   end
 end

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -9,14 +9,18 @@ Feature: Payments
     Then I should get redirected to the GOV.UK Pay page
       And I should have payment id in the session
 
-  Scenario: User wants to to finalize payment process
+  Scenario: User wants to finalize payment process
     Given I have finished the payment successfully
       And I'm getting redirected from GOV.UK Pay
     Then I should be on the successful payments page
 
-  Scenario: User wants to to finalize payment process
+  Scenario: User wants to finalize unsuccessful payment process
     Given I have finished the payment unsuccessfully
       And I'm getting redirected from GOV.UK Pay
     Then I should be on the failed payments page
 
-
+  Scenario: User wants to pay for another CAZ
+    Given I have finished the payment successfully
+      And I'm getting redirected from GOV.UK Pay
+    Then I press pay for another CAZ
+      And I should be on the local authorities page

--- a/features/step_definitions/payments_steps.rb
+++ b/features/step_definitions/payments_steps.rb
@@ -21,3 +21,8 @@ Then('I should have payment id in the session') do
   visit root_path
   expect(page.driver.request.session[:vehicle_details]['payment_id']).not_to be_nil
 end
+
+Then('I press pay for another CAZ') do
+  mock_vehicle_compliance
+  click_link 'Pay for another Clean Air Zone'
+end

--- a/spec/requests/payments_controller/failure_spec.rb
+++ b/spec/requests/payments_controller/failure_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe 'PaymentsController - GET #success', type: :request do
   subject(:http_request) { get failure_payments_path }
 
   let(:payment_id) { 'XYZ123ABC' }
+  let(:vrn) { 'CU57ABC' }
 
   before do
-    add_to_session(payment_id: payment_id)
+    add_to_session(payment_id: payment_id, vrn: vrn)
     subject
   end
 
@@ -16,7 +17,11 @@ RSpec.describe 'PaymentsController - GET #success', type: :request do
     expect(response).to have_http_status(:success)
   end
 
-  it 'clears details in session' do
-    expect(session[:vehicle_details]).to be_nil
+  it 'clears payment details in session' do
+    expect(session[:vehicle_details]['payment_id']).to be_nil
+  end
+
+  it 'does not clear other details in session' do
+    expect(session[:vehicle_details]['vrn']).to eq(vrn)
   end
 end

--- a/spec/requests/payments_controller/success_spec.rb
+++ b/spec/requests/payments_controller/success_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe 'PaymentsController - GET #success', type: :request do
     expect(response).to have_http_status(:success)
   end
 
-  it 'clears details in session' do
-    expect(session[:vehicle_details]).to be_nil
+  it 'clears payment details in session' do
+    expect(session[:vehicle_details]['payment_id']).to be_nil
+  end
+
+  it 'does not clear other details in session' do
+    expect(session[:vehicle_details]['vrn']).to eq(vrn)
   end
 end


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1343

## Description
<!--- Describe your changes in detail -->
Vehicle details were cleared too harsh. Now only those related to the payment are getting deleted after payment finalization.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go through the payment process and on success payment page click link described in the card.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
