### PR TITLE
[CAZ-1338] Add restart link to the failure page

### DIFF
--- a/app/views/payments/failure.html.haml
+++ b/app/views/payments/failure.html.haml
@@ -12,3 +12,9 @@
           %br
             %strong
               = @payment_id
+    .govuk-grid-column-one-third
+      %h2.govuk-heading-m
+        Other tasks
+      %ul.govuk-list.govuk-list--bullet
+        %li
+          = link_to 'Start a new payment', enter_details_vehicles_path

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -24,3 +24,9 @@ Feature: Payments
       And I'm getting redirected from GOV.UK Pay
     Then I press pay for another CAZ
       And I should be on the local authorities page
+
+  Scenario: User wants to start a new payment after unsuccessful payment process
+    Given I have finished the payment unsuccessfully
+      And I'm getting redirected from GOV.UK Pay
+    Then I press "Start a new payment" link
+      And I should be on the enter details page


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://eaflood.atlassian.net/browse/CAZ-1338

## Description
<!--- Describe your changes in detail -->

Just added a link with a feature test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
