### PR TITLE
[CAZ-1333] Redirect to compliant page when vehicle is exempted

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -67,6 +67,7 @@ class VehiclesController < ApplicationController
   #
   def details
     @vehicle_details = VehicleDetails.new(vrn)
+    return redirect_to(compliant_vehicles_path) if @vehicle_details.exempt?
 
     session[:vehicle_details]['taxi'] = true if @vehicle_details.taxi_private_hire_vehicle == 'Yes'
   end

--- a/app/models/vehicle_details.rb
+++ b/app/models/vehicle_details.rb
@@ -67,6 +67,11 @@ class VehicleDetails
     string_field('model')
   end
 
+  # Returns information if vehicle is exempted - boolean
+  def exempt?
+    compliance_api['exempt']
+  end
+
   private
 
   # Reader function for the vehicle registration number

--- a/spec/models/vehicle_details_spec.rb
+++ b/spec/models/vehicle_details_spec.rb
@@ -57,6 +57,24 @@ RSpec.describe VehicleDetails, type: :model do
     end
   end
 
+  describe '.exempt?' do
+    describe 'when key is not present' do
+      it 'returns a nil' do
+        expect(subject.exempt?).to eq(nil)
+      end
+    end
+
+    describe 'when key is present' do
+      before do
+        allow(ComplianceCheckerApi).to receive(:vehicle_details).and_return('exempt' => true)
+      end
+
+      it 'returns a true' do
+        expect(subject.exempt?).to eq(true)
+      end
+    end
+  end
+
   describe '.taxi_private_hire_vehicle' do
     describe 'when taxi_or_phv value is false' do
       it "returns a 'No'" do

--- a/spec/requests/vehicles_controller/details_spec.rb
+++ b/spec/requests/vehicles_controller/details_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe 'VehiclesController - GET #details', type: :request do
       http_request
       expect(response).to be_successful
     end
+
+    context 'when vehicle is exempted' do
+      let(:vehicle_details_stub) { instance_double('VehicleDetails', exempt?: true) }
+
+      before { allow(VehicleDetails).to receive(:new).and_return(vehicle_details_stub) }
+
+      it 'redirects to compliant path' do
+        http_request
+        expect(response).to redirect_to(compliant_vehicles_path)
+      end
+    end
   end
 
   context 'without VRN in session' do

--- a/spec/requests/vehicles_controller/submit_details_spec.rb
+++ b/spec/requests/vehicles_controller/submit_details_spec.rb
@@ -18,12 +18,10 @@ RSpec.describe 'VehiclesController - POST #submit_details', type: :request do
     end
 
     it 'sets VRN in the session' do
-      http_request
       expect(session[:vehicle_details][:vrn]).to eq(vrn)
     end
 
     it 'sets country in the session' do
-      http_request
       expect(session[:vehicle_details][:country]).to eq(country)
     end
   end


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Link to JIRA card](https://eaflood.atlassian.net/browse/CAZ-1333)

## Description
<!--- Describe your changes in detail -->
* Updated `VehicleDetails` model to include `exempt` field
* In `submit_details` action I added check which verifies if vehicle is exempted and redirects when needed.
* Added specs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually
* With RSpec

## Screenshots (if appropriate):
Video is in the comment on JIRA card

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
