### PR TITLE
[NT] Fix review back button and checking inputs on date select

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -106,9 +106,9 @@ class ChargesController < ApplicationController
   # Define the back button path on review payment page.
   def review_payment_return_path
     if vehicle_details('weekly')
-      weekly_charge_dates_path
+      select_weekly_date_dates_path
     else
-      daily_charge_dates_path
+      select_daily_date_dates_path
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,14 +23,6 @@ module ApplicationHelper
     end
   end
 
-  # Returns parsed date format, eg. '01/11/19 - 07/11/19'
-  def parse_weekly_dates(selected_date)
-    date = selected_date.to_date
-    first_day_of_week = date.strftime('%d/%m/%y')
-    last_day_of_week = (date + 6.days).strftime('%d/%m/%y')
-    "#{first_day_of_week} - #{last_day_of_week}"
-  end
-
   # Returns url path depends on which period was selected
   def determinate_payment_for_path(weekly_period)
     weekly_period ? select_period_dates_path : select_daily_date_dates_path

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -6,12 +6,12 @@ module DatesHelper
   # Checks if the date was already selected by the user.
   # Returns boolean.
   def checked_daily?(value)
-    session[:vehicle_details]['dates']&.include?(value)
+    session.dig(:vehicle_details, 'dates')&.include?(value)
   end
 
   # Checks if the date is the beginning of the previously selected period.
   # Returns boolean.
   def checked_weekly?(value)
-    value == session[:vehicle_details]['dates']&.first
+    value == session.dig(:vehicle_details, 'dates')&.first
   end
 end

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+##
+# Helper module for DatesController
+module DatesHelper
+  # Checks if the date was already selected by the user.
+  # Returns boolean.
+  def checked_daily?(value)
+    session[:vehicle_details]['dates']&.include?(value)
+  end
+
+  # Checks if the date is the beginning of the previously selected period.
+  # Returns boolean.
+  def checked_weekly?(value)
+    value == session[:vehicle_details]['dates']&.first
+  end
+end

--- a/app/views/charges/local_authority.html.haml
+++ b/app/views/charges/local_authority.html.haml
@@ -28,7 +28,8 @@
                   %input.govuk-radios__input{name: 'local-authority',
                                              type: 'radio',
                                              value: zone.id,
-                                             id: zone.name.downcase}
+                                             id: zone.name.downcase,
+                                             checked: zone.id == session[:vehicle_details]['la_id']}
                   %label.govuk-label.govuk-radios__label{for: zone.name.downcase}
                     = zone.name
         = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/app/views/dates/select_daily_date.html.haml
+++ b/app/views/dates/select_daily_date.html.haml
@@ -44,7 +44,8 @@
                   %input.govuk-checkboxes__input{name: 'dates[]',
                                                  type: 'checkbox',
                                                  value: date[:value],
-                                                 id: "date-#{index}"}
+                                                 id: "date-#{index}",
+                                                 checked: checked_daily?(date[:value])}
                   %label.govuk-label.govuk-checkboxes__label{for: "date-#{index}"}
                     - if date[:today]
                       %b

--- a/app/views/dates/select_weekly_date.html.haml
+++ b/app/views/dates/select_weekly_date.html.haml
@@ -40,7 +40,8 @@
                                                  name: 'dates[]',
                                                  type: 'radio',
                                                  value: date[:value],
-                                                 id: "date-#{index}"}
+                                                 id: "date-#{index}",
+                                                 checked: checked_weekly?(date[:value])}
                   %label.govuk-label.govuk-radios__label{for: "date-#{index}"}
                     - if date[:today]
                       %b

--- a/features/step_definitions/charges_steps.rb
+++ b/features/step_definitions/charges_steps.rb
@@ -50,7 +50,7 @@ Then('I have selected dates in the session') do
 end
 
 Then('I am on the review payment page') do
-  add_vehicle_details_to_session
+  add_vehicle_details_to_session(add_dates: true)
   mock_chargeable_caz
   mock_payment_creation
   visit review_payment_charges_path
@@ -77,7 +77,7 @@ Then('I press the Change Payment for link') do
 end
 
 Then('I am go the review payment page') do
-  add_vehicle_details_to_session
+  add_vehicle_details_to_session(add_dates: true)
   visit review_payment_charges_path
 end
 

--- a/features/support/session_helper.rb
+++ b/features/support/session_helper.rb
@@ -13,12 +13,9 @@ module SessionHelper
     page.set_rack_session(vehicle_details: compliance_details)
   end
 
-  def add_vehicle_details_to_session(add_payment_id: false)
-    details = {
-      **compliance_details,
-      dates: dates,
-      total_charge: dates.length * 9
-    }
+  def add_vehicle_details_to_session(add_dates: false, add_payment_id: false)
+    details = compliance_details
+    details.merge!(dates: dates, total_charge: dates.length * 9) if add_dates || add_payment_id
     details[:payment_id] = SecureRandom.uuid if add_payment_id
     page.set_rack_session(vehicle_details: details)
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,10 +20,4 @@ describe ApplicationHelper do
       expect(helper.parse_dates(array)).to be_a(Array)
     end
   end
-
-  describe '.parse_weekly_dates' do
-    it 'returns 7 next days' do
-      expect(helper.parse_weekly_dates('2019-11-01')).to eq('01/11/19 - 07/11/19')
-    end
-  end
 end

--- a/spec/helpers/dates_helper_spec.rb
+++ b/spec/helpers/dates_helper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DatesHelper do
+  let(:date) { '2019-11-03' }
+
+  describe '.checked_daily?' do
+    subject(:method) { helper.checked_daily?(date) }
+
+    let(:date) { '2019-11-01' }
+
+    context 'when there is no date in the session' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when date is in the session' do
+      before { session[:vehicle_details] = { 'dates' => [date] } }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when date is not in the session' do
+      before { session[:vehicle_details] = { 'dates' => ['2019-11-05'] } }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '.checked_weekly?' do
+    subject(:method) { helper.checked_weekly?(date) }
+
+    context 'when there is no date in the session' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when the date is the beginning of the period in the session' do
+      before do
+        session[:vehicle_details] = { 'dates' => (3..9).map { |day| "2019-11-0#{day}" } }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the date is not the beginning of the period in the session' do
+      before do
+        session[:vehicle_details] = { 'dates' => (1..7).map { |day| "2019-11-0#{day}" } }
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,7 @@ require 'rack_session_access'
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include AddToSession, type: :request
+  config.include AddToSession
   config.include ApiMocks
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/charges_controller/review_payment_spec.rb
+++ b/spec/requests/charges_controller/review_payment_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'ChargesController - GET #review_payment', type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      it 'assigns DatesController#daily_charge as return path' do
-        expect(assigns(:return_path)).to eq(daily_charge_dates_path)
+      it 'assigns DatesController#select_daily_date as return path' do
+        expect(assigns(:return_path)).to eq(select_daily_date_dates_path)
       end
 
       describe 'details' do
@@ -51,8 +51,8 @@ RSpec.describe 'ChargesController - GET #review_payment', type: :request do
         http_request
       end
 
-      it 'assigns DatesController#weekly_charge as return path' do
-        expect(assigns(:return_path)).to eq(weekly_charge_dates_path)
+      it 'assigns DatesController#select_weekly_date as return path' do
+        expect(assigns(:return_path)).to eq(select_weekly_date_dates_path)
       end
 
       it 'assigns weekly_period to true' do

--- a/spec/support/shared_examples/without_charge_in_session.rb
+++ b/spec/support/shared_examples/without_charge_in_session.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples 'charge is missing' do
-  it 'redirects to :enter_details_vehicles' do
-    expect(http_request).to redirect_to(enter_details_vehicles_path)
-  end
-end

--- a/spec/support/shared_examples/without_la_name_in_session.rb
+++ b/spec/support/shared_examples/without_la_name_in_session.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples 'la name is missing' do
-  it 'redirects to :enter_details_vehicles' do
-    expect(http_request).to redirect_to(enter_details_vehicles_path)
-  end
-end

--- a/spec/support/test_session_monkey_patch.rb
+++ b/spec/support/test_session_monkey_patch.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ActionController
+  # TestSession used in helper tests doesn't have dig method
+  class TestSession < Rack::Session::Abstract::SessionHash
+    def dig(*keys)
+      to_h.dig(*keys.map(&:to_s))
+    end
+  end
+end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed that the back button on the review page does not lead to the previous page but to some earlier step. 
Also, checkboxes on picking dates should be marked when you go back.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
