### PR TITLE
[CAZ-1370] Change Leeds taxi recognition

### DIFF
--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -38,6 +38,7 @@ class ComplianceCheckerApi < BaseApi
     # * +colour+ - string, eg. 'red'
     # * +fuelType+ - string, eg. 'diesel'
     # * +taxiOrPhv+ - boolean, determines if the vehicle is a taxi or a PHV
+    # * +licensingAuthoritiesNames+ - array of strings, list of LA where vehicle is registered as a taxi
     # * +exempt+ - boolean, determines if the vehicle is exempt from charges
     #
     # ==== Serialization

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -65,9 +65,7 @@ class VehiclesController < ApplicationController
     @vehicle_details = VehicleDetails.new(vrn)
     return redirect_to(compliant_vehicles_path) if @vehicle_details.exempt?
 
-    if @vehicle_details.taxi_private_hire_vehicle == 'Yes'
-      SessionManipulation::SetTaxi.call(session: session)
-    end
+    SessionManipulation::SetLeedsTaxi.call(session: session) if @vehicle_details.leeds_taxi?
   end
 
   ##

--- a/app/models/vehicle_details.rb
+++ b/app/models/vehicle_details.rb
@@ -72,6 +72,11 @@ class VehicleDetails
     compliance_api['exempt']
   end
 
+  # Returns if vehicle is register in Leeds as taxi or PHV
+  def leeds_taxi?
+    compliance_api['licensingAuthoritiesNames']&.include?('Leeds')
+  end
+
   private
 
   # Reader function for the vehicle registration number

--- a/app/services/session_manipulation/base_manipulator.rb
+++ b/app/services/session_manipulation/base_manipulator.rb
@@ -14,7 +14,7 @@ module SessionManipulation
     # Subkeys of vehicle values in order of setting
     SUBKEYS = {
       1 => %w[vrn country],
-      2 => %w[taxi unrecognised],
+      2 => %w[leeds_taxi unrecognised],
       3 => %w[type incorrect],
       4 => %w[la_id daily_charge la_name weekly_possible],
       5 => %w[dates total_charge weekly],

--- a/app/services/session_manipulation/set_compliance_details.rb
+++ b/app/services/session_manipulation/set_compliance_details.rb
@@ -36,7 +36,8 @@ module SessionManipulation
         la_id: la_id,
         la_name: compliance_details.zone_name,
         daily_charge: compliance_details.charge,
-        weekly_possible: session[SESSION_KEY]['taxi'] && compliance_details.zone_name == 'Leeds'
+        weekly_possible:
+          session[SESSION_KEY]['leeds_taxi'] && compliance_details.zone_name == 'Leeds'
       )
     end
 

--- a/app/services/session_manipulation/set_leeds_taxi.rb
+++ b/app/services/session_manipulation/set_leeds_taxi.rb
@@ -2,18 +2,18 @@
 
 module SessionManipulation
   ##
-  # Service used to mark vehicle as a taxi of PHV.
+  # Service used to mark vehicle as a taxi of PHV registered in Leeds.
   #
   # ==== Usage
   #    SessionManipulation::SetTaxi.call(session: session)
   #
-  class SetTaxi < BaseManipulator
+  class SetLeedsTaxi < BaseManipulator
     # Level used to clearing keys in the session
     LEVEL = 2
 
-    # Sets +taxi+ to true in the session. Used by the class level method +.call+
+    # Sets +leeds_taxi+ to true in the session. Used by the class level method +.call+
     def call
-      add_fields(taxi: true)
+      add_fields(leeds_taxi: true)
     end
   end
 end

--- a/spec/fixtures/files/vehicle_details_taxi_response.json
+++ b/spec/fixtures/files/vehicle_details_taxi_response.json
@@ -6,5 +6,6 @@
   "model": "208",
   "colour": "grey",
   "fuelType": "diesel",
-  "taxiOrPhv": true
+  "taxiOrPhv": true,
+  "licensingAuthoritiesNames": ["Leeds", "Birmingham"]
 }

--- a/spec/models/vehicle_details_spec.rb
+++ b/spec/models/vehicle_details_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe VehicleDetails, type: :model do
   let(:type_approval) { 'M1' }
   let(:taxi_or_phv) { false }
   let(:type) { 'car' }
+  let(:las) { %w[Leeds Birmingham] }
 
   let(:response) do
     {
@@ -19,7 +20,8 @@ RSpec.describe VehicleDetails, type: :model do
       'model' => '208',
       'colour' => 'grey',
       'fuelType' => 'diesel',
-      'taxiOrPhv' => taxi_or_phv
+      'taxiOrPhv' => taxi_or_phv,
+      'licensingAuthoritiesNames' => las
     }
   end
 
@@ -158,6 +160,32 @@ RSpec.describe VehicleDetails, type: :model do
       it 'returns a nil' do
         expect(compliance.undetermined?).to eq('true')
       end
+    end
+  end
+
+  describe '.leeds_taxi?' do
+    subject(:taxi) { compliance.leeds_taxi? }
+
+    context 'when Leeds is in licensingAuthoritiesNames' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when Leeds is NOT in licensingAuthoritiesNames' do
+      let(:las) { %w[Birmingham London] }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when licensingAuthoritiesNames is empty' do
+      let(:las) { [] }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when licensingAuthoritiesNames is nil' do
+      let(:las) { nil }
+
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/requests/charges_controller/submit_local_authority_spec.rb
+++ b/spec/requests/charges_controller/submit_local_authority_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'ChargesController - POST #submit_local_authority', type: :reques
 
       context 'when vehicle is a taxi in Leeds' do
         before do
-          add_to_session(vrn: 'CU57ABC', country: 'UK', taxi: true)
+          add_to_session(vrn: 'CU57ABC', country: 'UK', leeds_taxi: true)
         end
 
         it 'returns redirect to DatesController#select_period' do

--- a/spec/requests/vehicles_controller/details_spec.rb
+++ b/spec/requests/vehicles_controller/details_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'VehiclesController - GET #details', type: :request do
       end
 
       it 'sets taxi in the session' do
-        expect(session[:vehicle_details]['taxi']).to be_truthy
+        expect(session[:vehicle_details]['leeds_taxi']).to be_truthy
       end
     end
   end

--- a/spec/services/session_manipulation/clear_payment_details_spec.rb
+++ b/spec/services/session_manipulation/clear_payment_details_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SessionManipulation::ClearPaymentDetails do
     {
       'vrn' => 'CU123AB',
       'country' => 'UK',
-      'taxi' => true,
+      'leeds_taxi' => true,
       'unrecognised' => true,
       'type' => 'car',
       'incorrect' => true,
@@ -29,7 +29,7 @@ RSpec.describe SessionManipulation::ClearPaymentDetails do
   it 'clears details from steps above vehicle details' do
     service
     expect(session[:vehicle_details].keys).to contain_exactly(
-      'vrn', 'country', 'taxi', 'unrecognised', 'type', 'incorrect'
+      'vrn', 'country', 'leeds_taxi', 'unrecognised', 'type', 'incorrect'
     )
   end
 end

--- a/spec/services/session_manipulation/set_compliance_details_spec.rb
+++ b/spec/services/session_manipulation/set_compliance_details_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe SessionManipulation::SetComplianceDetails do
       expect(session[:vehicle_details]['weekly_possible']).to be_falsey
     end
 
-    context 'when vehicle is a taxi' do
-      let(:session) { { vehicle_details: details.merge('taxi' => true) } }
+    context 'when vehicle is a taxi in Leeds' do
+      let(:session) { { vehicle_details: details.merge('leeds_taxi' => true) } }
 
       it 'sets weekly_possible to true' do
         expect(session[:vehicle_details]['weekly_possible']).to be_truthy

--- a/spec/services/session_manipulation/set_leeds_taxi_spec.rb
+++ b/spec/services/session_manipulation/set_leeds_taxi_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SessionManipulation::SetTaxi do
+RSpec.describe SessionManipulation::SetLeedsTaxi do
   subject(:service) { described_class.call(session: session) }
 
   let(:session) { { vehicle_details: details } }
@@ -12,7 +12,7 @@ RSpec.describe SessionManipulation::SetTaxi do
 
   it 'sets taxi' do
     service
-    expect(session[:vehicle_details]['taxi']).to be_truthy
+    expect(session[:vehicle_details]['leeds_taxi']).to be_truthy
   end
 
   context 'when session is already filled with more data' do
@@ -22,7 +22,7 @@ RSpec.describe SessionManipulation::SetTaxi do
 
     it 'clears keys from next steps' do
       service
-      expect(session[:vehicle_details].keys).to contain_exactly('vrn', 'country', 'taxi')
+      expect(session[:vehicle_details].keys).to contain_exactly('vrn', 'country', 'leeds_taxi')
     end
   end
 end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1370

## Description
<!--- Describe your changes in detail -->
added `.leeds_taxi?` to `VehcileDetails` which determines whether to add `leeds_taxi: true` to the session or not/.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
