### PR TITLE
[CAZ-1497] Fix fetching chargeable LAs for non-DVLA

### DIFF
--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -145,7 +145,7 @@ class ComplianceCheckerApi < BaseApi
     # ==== Attributes
     #
     # * +type+ - string, eg. 'car'
-    # * +zone_id+ - string, zone ID which vehicle compliance is check against
+    # * +zones+ - Array of zones IDs which vehicle compliance is check against
     #
     # ==== Result
     #
@@ -155,10 +155,14 @@ class ComplianceCheckerApi < BaseApi
     #   * +name+ - string, eg. "Birmingham"
     #   * +charge+ - number, determines how much owner of the vehicle will have to pay in this CAZ
     #
-    def unrecognised_compliance(type, zone_id)
-      log_action "Getting vehicle unrecognised type compliance, type: #{type}, zone_id: #{zone_id}"
-      endpoint = "/vehicles/unrecognised/#{type}/compliance"
-      request(:get, endpoint, query: { zones: zone_id })
+    def unrecognised_compliance(type, zones)
+      zones = zones.join(',')
+      log_action "Getting vehicle unrecognised type compliance, type: #{type}, zones: #{zones}"
+      request(
+        :get,
+        "/vehicles/unrecognised/#{type}/compliance",
+        query: { zones: zones }
+      )
     end
   end
 end

--- a/app/models/compliance_details.rb
+++ b/app/models/compliance_details.rb
@@ -79,6 +79,6 @@ class ComplianceDetails
 
   # Get compliance data for non-DVLA registered vehicle
   def non_dvla_compliance_data
-    ComplianceCheckerApi.unrecognised_compliance(type, zone_id)['charges']
+    ComplianceCheckerApi.unrecognised_compliance(type, [zone_id])['charges']
   end
 end

--- a/app/services/chargeable_zones_service.rb
+++ b/app/services/chargeable_zones_service.rb
@@ -13,6 +13,8 @@ class ChargeableZonesService < BaseService
   #   * +vrn+ - string, eg. 'CU57ABC'
   #   * +country+ - string, country of the vehicle registration - UK or non-UK
   #   * +unrecognised+ - boolean, unrecognised vehicle's registration
+  #   * +type+ - string, type of the vehicle selected by the user
+  #
   def initialize(vehicle_details:)
     @vrn = vehicle_details['vrn']
     @type = vehicle_details['type']

--- a/spec/fixtures/files/caz_list_response.json
+++ b/spec/fixtures/files/caz_list_response.json
@@ -1,12 +1,12 @@
 {
   "cleanAirZones": [
     {
-      "cleanAirZoneId": "5cd7441d-766f-48ff-b8ad-1809586fea37",
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
       "name": "Birmingham",
       "boundaryUrl": "https://www.birmingham.gov.uk/info/20076/pollution/1763/a_clean_air_zone_for_birmingham/3"
     },
     {
-      "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
       "name": "Leeds",
       "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621"
     }

--- a/spec/fixtures/files/unrecognised_one_charge_response.json
+++ b/spec/fixtures/files/unrecognised_one_charge_response.json
@@ -1,0 +1,15 @@
+{
+  "charges":
+  [
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
+      "name": "Birmingham",
+      "charge": 8.5
+    },
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
+      "name": "Leeds",
+      "charge": 0.0
+    }
+  ]
+}

--- a/spec/fixtures/files/unrecognised_vehicle_response.json
+++ b/spec/fixtures/files/unrecognised_vehicle_response.json
@@ -5,6 +5,11 @@
       "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
       "name": "Birmingham",
       "charge": 15
+    },
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
+      "name": "Leeds",
+      "charge": 20
     }
   ]
 }

--- a/spec/fixtures/files/vehicle_compliance_many_charges_response.json
+++ b/spec/fixtures/files/vehicle_compliance_many_charges_response.json
@@ -1,0 +1,39 @@
+{
+  "registrationNumber": "CAS310",
+  "retrofitted": false,
+  "exempt": false,
+  "complianceOutcomes": [
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
+      "name": "Birmingham",
+      "charge": 10.0,
+      "informationUrls": {
+        "emissionsStandards": "http://test.com",
+        "mainInfo": "http://test.com",
+        "hoursOfOperation": "http://test.com",
+        "pricing": "http://test.com",
+        "exemptionOrDiscount": "http://test.com",
+        "payCaz": "http://test.com",
+        "becomeCompliant": "http://test.com",
+        "financialAssistance": "http://test.com",
+        "boundary": "http://test.com"
+      }
+    },
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
+      "name": "Leeds",
+      "charge": 10.0,
+      "informationUrls": {
+        "emissionsStandards": "http://test.com",
+        "mainInfo": "http://test.com",
+        "hoursOfOperation": "http://test.com",
+        "pricing": "http://test.com",
+        "exemptionOrDiscount": "http://test.com",
+        "payCaz": "http://test.com",
+        "becomeCompliant": "http://test.com",
+        "financialAssistance": "http://test.com",
+        "boundary": "http://test.com"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/vehicle_compliance_one_charge_response.json
+++ b/spec/fixtures/files/vehicle_compliance_one_charge_response.json
@@ -1,0 +1,39 @@
+{
+  "registrationNumber": "CAS310",
+  "retrofitted": false,
+  "exempt": false,
+  "complianceOutcomes": [
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
+      "name": "Birmingham",
+      "charge": 8.0,
+      "informationUrls": {
+        "emissionsStandards": "http://test.com",
+        "mainInfo": "http://test.com",
+        "hoursOfOperation": "http://test.com",
+        "pricing": "http://test.com",
+        "exemptionOrDiscount": "http://test.com",
+        "payCaz": "http://test.com",
+        "becomeCompliant": "http://test.com",
+        "financialAssistance": "http://test.com",
+        "boundary": "http://test.com"
+      }
+    },
+    {
+      "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
+      "name": "Leeds",
+      "charge": 0.0,
+      "informationUrls": {
+        "emissionsStandards": "http://test.com",
+        "mainInfo": "http://test.com",
+        "hoursOfOperation": "http://test.com",
+        "pricing": "http://test.com",
+        "exemptionOrDiscount": "http://test.com",
+        "payCaz": "http://test.com",
+        "becomeCompliant": "http://test.com",
+        "financialAssistance": "http://test.com",
+        "boundary": "http://test.com"
+      }
+    }
+  ]
+}

--- a/spec/models/compliance_details_spec.rb
+++ b/spec/models/compliance_details_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ComplianceDetails, type: :model do
   let(:country) { 'UK' }
   let(:zone_id) { SecureRandom.uuid }
   let(:unrecognised) { false }
-  let(:type) { 'car' }
+  let(:type) { 'private_car' }
 
   let(:outcomes) do
     [
@@ -92,14 +92,14 @@ RSpec.describe ComplianceDetails, type: :model do
       before do
         allow(ComplianceCheckerApi)
           .to receive(:unrecognised_compliance)
-          .with(type, zone_id)
+          .with(type, [zone_id])
           .and_return(unrecognised_response)
       end
 
       it 'calls :unrecognised_compliance with right params' do
         expect(ComplianceCheckerApi)
           .to receive(:unrecognised_compliance)
-          .with(type, zone_id)
+          .with(type, [zone_id])
         details.zone_name
       end
 
@@ -116,14 +116,14 @@ RSpec.describe ComplianceDetails, type: :model do
     before do
       allow(ComplianceCheckerApi)
         .to receive(:unrecognised_compliance)
-        .with(type, zone_id)
+        .with(type, [zone_id])
         .and_return(unrecognised_response)
     end
 
     it 'calls :unrecognised_compliance with right params' do
       expect(ComplianceCheckerApi)
         .to receive(:unrecognised_compliance)
-        .with(type, zone_id)
+        .with(type, [zone_id])
       details.zone_name
     end
   end

--- a/spec/support/api_mocks.rb
+++ b/spec/support/api_mocks.rb
@@ -23,7 +23,15 @@ module ApiMocks
 
   # Mocks response from compliance endpoint in VCCS API
   def mock_vehicle_compliance
-    compliance_data = read_file('vehicle_compliance_birmingham_response.json')
+    compliance_data = read_file('vehicle_compliance_many_charges_response.json')
+    allow(ComplianceCheckerApi)
+      .to receive(:vehicle_compliance)
+      .and_return(compliance_data)
+  end
+
+  # Mocks response from compliance endpoint in VCCS API with zero charge for Leeds
+  def mock_private_car_compliance
+    compliance_data = read_file('vehicle_compliance_one_charge_response.json')
     allow(ComplianceCheckerApi)
       .to receive(:vehicle_compliance)
       .and_return(compliance_data)
@@ -34,5 +42,19 @@ module ApiMocks
     allow(ComplianceCheckerApi)
       .to receive(:vehicle_compliance)
       .and_return(compliance_data)
+  end
+
+  def mock_unrecognised_compliance(one_charge = false)
+    compliance_data = read_file(
+      one_charge ? 'unrecognised_one_charge_response.json' : 'unrecognised_vehicle_response.json'
+    )
+    allow(ComplianceCheckerApi)
+      .to receive(:unrecognised_compliance)
+      .and_return(compliance_data)
+  end
+
+  def mocked_zone_ids
+    caz_list = read_file('caz_list_response.json')['cleanAirZones']
+    caz_list.map { |caz| caz['cleanAirZoneId'] }
   end
 end

--- a/spec/support/api_mocks.rb
+++ b/spec/support/api_mocks.rb
@@ -29,7 +29,7 @@ module ApiMocks
       .and_return(compliance_data)
   end
 
-  # Mocks response from compliance endpoint in VCCS API with zero charge for Leeds
+  # Mocks response from compliance endpoint in VCCS API with zero charge for Leeds.
   def mock_private_car_compliance
     compliance_data = read_file('vehicle_compliance_one_charge_response.json')
     allow(ComplianceCheckerApi)
@@ -37,6 +37,7 @@ module ApiMocks
       .and_return(compliance_data)
   end
 
+  # Mocks response from compliance endpoint in VCCS API for compliant vehicle.
   def mock_vehicle_with_zero_charge
     compliance_data = read_file('vehicle_compliance_with_zero_charge_response.json')
     allow(ComplianceCheckerApi)
@@ -44,6 +45,8 @@ module ApiMocks
       .and_return(compliance_data)
   end
 
+  # Mocks compliance data for non-DVLA vehicle.
+  # If +one_charge+ is set to true, it returns zero as charge for Leeds.
   def mock_unrecognised_compliance(one_charge = false)
     compliance_data = read_file(
       one_charge ? 'unrecognised_one_charge_response.json' : 'unrecognised_vehicle_response.json'
@@ -53,6 +56,7 @@ module ApiMocks
       .and_return(compliance_data)
   end
 
+  # Returns an array with mocker zone IDs. Used to check params.
   def mocked_zone_ids
     caz_list = read_file('caz_list_response.json')['cleanAirZones']
     caz_list.map { |caz| caz['cleanAirZoneId'] }

--- a/spec/support/shared_examples/chareable_zones_service.rb
+++ b/spec/support/shared_examples/chareable_zones_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a chargeable zones service' do |size = 2|
+  it 'returns a list of Caz' do
+    expect(service_call).to all(be_a(Caz))
+  end
+
+  it "returns #{size} Caz objects" do
+    expect(service_call.length).to eq(size)
+  end
+
+  it 'sets name in Caz objects' do
+    expect(service_call.map(&:name)).to all(be_a(String))
+  end
+
+  it 'calls ComplianceCheckerApi.clean_air_zones' do
+    expect(ComplianceCheckerApi).to receive(:clean_air_zones)
+    service_call
+  end
+end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1497

## Description
<!--- Describe your changes in detail -->
`ChareableZoneService` know will iterate over compliance data the same way for DVLA and non-DVLA vehicles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
