### PR TITLE
Merge small and large van types into one

### DIFF
--- a/app/services/vehicle_types.rb
+++ b/app/services/vehicle_types.rb
@@ -23,9 +23,8 @@ class VehicleTypes < BaseService
       { value: 'bus', name: 'Bus' },
       { value: 'coach', name: 'Coach' },
       { value: 'hgv', name: 'Heavy goods vehicle' },
-      { value: 'large_van', name: 'Large van' },
+      { value: 'van', name: 'Van' },
       { value: 'minibus', name: 'Minibus' },
-      { value: 'small_van', name: 'Small van' },
       { value: 'private_car', name: 'Car' },
       { value: 'motorcycle', name: 'Motorcycle' }
     ]

--- a/spec/services/vehicle_types_spec.rb
+++ b/spec/services/vehicle_types_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe VehicleTypes do
   subject(:service_call) { described_class.call }
 
-  it 'returns 9 types' do
-    expect(service_call.length).to eq(8)
+  it 'returns 7 types' do
+    expect(service_call.length).to eq(7)
   end
 
   it 'returns objects with name and value' do


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Tariff Service no longer has a concept of 'Small Van' and 'Large Van' - necessitating a merge of the two into 'Van'.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Specification for Vehicle Type service has been updated to only expect 7 types of vehicles for unrecognised and non-UK vehicles.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
