### PR TITLE
[Fix] [CAZ-1906] Reverse errors on enter_details.html.haml

### DIFF
--- a/app/views/vehicles/enter_details.html.haml
+++ b/app/views/vehicles/enter_details.html.haml
@@ -12,7 +12,7 @@
             There is a problem
           .govuk-error-summary__body
             %ul.govuk-list.govuk-error-summary__list
-              - @errors.each do |field, messages|
+              - @errors.reverse_each do |field, messages|
                 %li
                   = link_to(messages.first, "##{field}-error")
       %h1.govuk-heading-xl


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1906

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screen Shot 2020-01-31 at 14 08 52](https://user-images.githubusercontent.com/16211686/73541874-c6598d80-4433-11ea-8e21-3c9d2bc7648f.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
