### PR TITLE
[FIX] [CAZ-1918] Add non-UK VRN format check

### DIFF
--- a/app/models/vrn_form.rb
+++ b/app/models/vrn_form.rb
@@ -22,7 +22,10 @@ class VrnForm
     maximum: 7, too_long: I18n.t('vrn_form.vrn_too_long')
   }, if: -> { uk? }
   # Checks if VRN is in valid format when vehicle is registered in the UK
-  validate :vrn_format, if: -> { uk? }
+  validate :vrn_uk_format, if: -> { uk? }
+
+  # Checks if VRN contains only alphanumerics when vehicle is not registered in the UK
+  validate :vrn_non_uk_format, unless: -> { uk? }
 
   ##
   # Initializer method
@@ -45,11 +48,23 @@ class VrnForm
   end
 
   # Checks if VRN matches any possible VRN format
-  def vrn_format
+  def vrn_uk_format
     return if FORMAT_REGEXPS.any? do |reg|
       reg.match(vrn).present?
     end
 
+    add_format_error
+  end
+
+  # Checks if VRN contains only alphanumerics
+  def vrn_non_uk_format
+    return if /^[A-Za-z0-9]+$/.match(vrn).present?
+
+    add_format_error
+  end
+
+  # Adds format error
+  def add_format_error
     errors.add(:vrn, I18n.t('vrn_form.vrn_invalid'))
   end
 

--- a/spec/models/vrn_form_spec.rb
+++ b/spec/models/vrn_form_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe VrnForm, type: :model do
+describe VrnForm, type: :model do
   subject(:form) { described_class.new(vrn, country) }
 
   let(:vrn) { 'CU57ABC' }
@@ -101,7 +101,7 @@ RSpec.describe VrnForm, type: :model do
       context 'when VRN has special signs' do
         let(:vrn) { 'ABCDE$%' }
 
-        it { is_expected.to be_valid }
+        it_behaves_like 'an invalid vrn input', I18n.t('vrn_form.vrn_invalid')
       end
 
       context 'when VRN has too many numbers' do


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1918

## Description
<!--- Describe your changes in detail -->
Add format check for non_UK VRNs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screen Shot 2020-02-04 at 07 50 44](https://user-images.githubusercontent.com/16211686/73720790-1893fa80-4723-11ea-8e85-f56b0dd2e56b.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
