### PR TITLE
Remove charge reference terms in favour of Payment ID

### DIFF
--- a/app/views/payments/failure.html.haml
+++ b/app/views/payments/failure.html.haml
@@ -9,7 +9,7 @@
         Payment reference:
         = @payment_details.reference
         %br
-        Charge reference:
+        Payment ID:
         = @payment_details.external_id
       %p
         You may need these reference numbers if you contact us or your bank about this payment.

--- a/app/views/payments/success.html.haml
+++ b/app/views/payments/success.html.haml
@@ -12,7 +12,7 @@
             %strong
               = @payment_details.reference
           %br
-          Charge reference
+          Payment ID
           %br
             %strong
               = @payment_details.external_id


### PR DESCRIPTION
Updates references to Charge reference such that they read Payment ID following discussion with Product Owner