### PR TITLE
[CAZ-2047] Proxy VCCS calls through Payments API

### DIFF
--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 ##
-# This class wraps calls being made to the VCCS backend API.
-# The base URL for the calls is configured by +COMPLIANCE_CHECKER_API_URL+ environment variable.
+# This class wraps calls being made to the Payments backend API related to Vehicle Compliance.
+# The base URL for the calls is configured by +PAYMENTS_API_URL+ environment variable.
 #
 # All calls will automatically have the correlation ID and JSON content type added to the header.
 #
 # All methods are on the class level, so there is no initializer method.
 
 class ComplianceCheckerApi < BaseApi
-  base_uri ENV.fetch('COMPLIANCE_CHECKER_API_URL', 'localhost:3001') + '/v1/compliance-checker'
+  base_uri ENV.fetch('PAYMENTS_API_URL', 'localhost:3001') + '/v1/payments'
 
   class << self
     ##
-    # Calls +/v1/compliance-checker/vehicles/:vrn/details+ endpoint with +GET+ method
+    # Calls +/v1/payments/vehicles/:vrn/details+ endpoint with +GET+ method
     # and returns details of the requested vehicle.
     #
     # ==== Attributes
@@ -53,7 +53,7 @@ class ComplianceCheckerApi < BaseApi
     end
 
     ##
-    # Calls +/v1/compliance-checker/vehicles/:vrn/compliance+ endpoint with +GET+ method
+    # Calls +/v1/payments/vehicles/:vrn/compliance+ endpoint with +GET+ method
     # and returns compliance details of the requested vehicle for requested zones.
     #
     # ==== Attributes
@@ -106,7 +106,7 @@ class ComplianceCheckerApi < BaseApi
     end
 
     ##
-    # Calls +/v1/compliance-checker/clean-air-zones+ endpoint with +GET+ method
+    # Calls +/v1/payments/clean-air-zones+ endpoint with +GET+ method
     # and returns the list of available Clean Air Zones.
     #
     # ==== Example
@@ -134,7 +134,7 @@ class ComplianceCheckerApi < BaseApi
     end
 
     ##
-    # Calls +/v1/compliance-checker/vehicles/unrecognised/:type/compliance+ endpoint with +GET+ method
+    # Calls +/v1/payments/vehicles/unrecognised/:type/compliance+ endpoint with +GET+ method
     # and returns compliance details for non DVLA vehicle on requested zone.
     #
     # ==== Attributes


### PR DESCRIPTION
**THIS PR IS WIP AND CANNOT BE MERGED UNTIL ALL PROXY ENDPOINTS ARE IN PLACE**

## Motivation and Context
API Calls were made from Payments UI to VCCS API which is against
architecture we are building. Now with proxy endpoints being added
on top of Payments API we can now move all API calls there.

## Description
https://eaflood.atlassian.net/browse/CAZ-2047
<!--- Describe your changes in detail -->
This commit makes sure we are not making any direct API calls to VCCS API layer,
but instead are using newly created proxy endpoints under Payments API Gateway.
It is needed to be consistent with C4 models, and respect system boundaries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To my knowledge this is configuration change that is going to be tested on DEV environment

## Screenshots (if appropriate):
DO NOT APPLY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
