### PR TITLE
Persist inputs so they can be re-rendered when clicking back links

### DIFF
--- a/app/controllers/dates_controller.rb
+++ b/app/controllers/dates_controller.rb
@@ -83,12 +83,13 @@ class DatesController < ApplicationController
   #
   def confirm_daily_charge
     form = ConfirmationForm.new(params['confirm-exempt'])
-    unless form.valid?
+    if form.valid?
+      SessionManipulation::SetConfirmExempt.call(session: session)
+      redirect_to select_daily_date_dates_path
+    else
       alert = I18n.t('confirmation_form.exemption')
-      return redirect_back_to(daily_charge_dates_path, alert, :daily_charge)
+      redirect_back_to(daily_charge_dates_path, alert, :daily_charge)
     end
-    SessionManipulation::SetConfirmExempt.call(session: session)
-    redirect_to select_daily_date_dates_path
   end
 
   ##
@@ -217,9 +218,7 @@ class DatesController < ApplicationController
   def confirm_date_weekly
     dates = params[:dates]
     if dates && check_already_paid_weekly(dates)
-      SessionManipulation::CalculateTotalCharge.call(
-        session: session, dates: dates, weekly: true
-      )
+      SessionManipulation::CalculateTotalCharge.call(session: session, dates: dates, weekly: true)
       redirect_to review_payment_charges_path
     else
       alert = I18n.t(dates ? 'paid' : 'empty', scope: 'dates.weekly')

--- a/app/controllers/non_dvla_vehicles_controller.rb
+++ b/app/controllers/non_dvla_vehicles_controller.rb
@@ -43,6 +43,7 @@ class NonDvlaVehiclesController < ApplicationController
   def confirm_registration
     form = ConfirmationForm.new(params['confirm-registration'])
     if form.confirmed?
+      SessionManipulation::SetConfirmRegistration.call(session: session)
       redirect_to choose_type_non_dvla_vehicles_path
     else
       redirect_to non_dvla_vehicles_path, alert: true

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -226,6 +226,7 @@ class VehiclesController < ApplicationController
     ]
   end
 
+  # persists whether or not vehicle details are correct into session and returns correct onward path
   def process_detail_form(form)
     SessionManipulation::SetConfirmVehicle.call(session: session, confirm_vehicle: form.confirmed?)
     form.confirmed? ? local_authority_charges_path : incorrect_details_vehicles_path

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -92,8 +92,7 @@ class VehiclesController < ApplicationController
       log_invalid_form 'Redirecting back.'
       return redirect_to details_vehicles_path, alert: form.errors.messages[:confirmation].first
     end
-
-    redirect_to form.confirmed? ? local_authority_charges_path : incorrect_details_vehicles_path
+    redirect_to process_detail_form(form)
   end
 
   ##
@@ -128,7 +127,6 @@ class VehiclesController < ApplicationController
   # * +vrn+ - lack of VRN redirects to {enter_details}[rdoc-ref:VehiclesController.enter_details]
   #
   def unrecognised
-    SessionManipulation::SetUnrecognised.call(session: session)
     @vrn = vrn
   end
 
@@ -151,6 +149,7 @@ class VehiclesController < ApplicationController
   def confirm_unrecognised
     form = ConfirmationForm.new(params['confirm-registration'])
     if form.confirmed?
+      SessionManipulation::SetUnrecognised.call(session: session)
       redirect_to choose_type_non_dvla_vehicles_path
     else
       log_invalid_form 'Redirecting back.'
@@ -208,7 +207,8 @@ class VehiclesController < ApplicationController
   # Returns path depends on last request
   def determinate_back_path
     last_request = request.referer
-    if back_button_paths.any? { |path| last_request.include?(path) }
+    back = request.query_parameters.include?('back')
+    if !back && back_button_paths.any? { |path| last_request.include?(path) }
       last_request
     else
       root_path
@@ -224,5 +224,10 @@ class VehiclesController < ApplicationController
       compliant_vehicles_path,
       exempt_vehicles_path
     ]
+  end
+
+  def process_detail_form(form)
+    SessionManipulation::SetConfirmVehicle.call(session: session, confirm_vehicle: form.confirmed?)
+    form.confirmed? ? local_authority_charges_path : incorrect_details_vehicles_path
   end
 end

--- a/app/services/session_manipulation/base_manipulator.rb
+++ b/app/services/session_manipulation/base_manipulator.rb
@@ -13,15 +13,18 @@ module SessionManipulation
 
     # Subkeys of vehicle values in order of setting
     SUBKEYS = {
-      1 => %w[vrn country],
-      2 => %w[leeds_taxi unrecognised],
-      3 => %w[type],
-      4 => %w[incorrect],
-      5 => %w[chargeable_zones],
-      6 => %w[la_id daily_charge la_name weekly_possible tariff_code],
-      7 => %w[dates total_charge weekly],
-      8 => %w[payment_id],
-      9 => %w[user_email payment_reference external_id]
+      1 => %w[vrn country confirm_vehicle],
+      2 => %w[unrecognised leeds_taxi confirm_registration],
+      3 => %w[confirm_vehicle],
+      4 => %w[type],
+      5 => %w[incorrect la_id],
+      6 => %w[chargeable_zones],
+      7 => %w[daily_charge la_name weekly_possible tariff_code],
+      8 => %w[charge_period],
+      9 => %w[confirm_exempt],
+      10 => %w[dates total_charge weekly],
+      11 => %w[payment_id],
+      12 => %w[user_email payment_reference external_id]
     }.freeze
 
     # Base initializer for the service

--- a/app/services/session_manipulation/calculate_total_charge.rb
+++ b/app/services/session_manipulation/calculate_total_charge.rb
@@ -11,7 +11,7 @@ module SessionManipulation
   #
   class CalculateTotalCharge < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 7
+    LEVEL = 10
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/clear_payment_details.rb
+++ b/app/services/session_manipulation/clear_payment_details.rb
@@ -21,7 +21,7 @@ module SessionManipulation
 
     # Returns keys from steps before selecting LA
     def keys_to_keep
-      SUBKEYS.select { |key| key < 6 }.values.flatten
+      SUBKEYS.select { |key| key < 7 }.values.flatten
     end
   end
 end

--- a/app/services/session_manipulation/set_charge_period.rb
+++ b/app/services/session_manipulation/set_charge_period.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Service used to confirm charge period.
+  #
+  # ==== Usage
+  #    SessionManipulation::SetChargePeriod.call(session: session)
+  #
+  class SetChargePeriod < BaseManipulator
+    # Level used to clearing keys in the session
+    LEVEL = 8
+
+    # Initializer function. Used by the class level method +.call+
+    #
+    # ==== Attributes
+    # * +session+ - the user's session
+    # * +confirm_vehicle+ - a boolean
+    #
+    def initialize(session:, charge_period:)
+      @session = session
+      @charge_period = charge_period
+    end
+
+    # Sets +confirm_vehicle+ in the session. Used by the class level method +.call+
+    def call
+      add_fields(charge_period: @charge_period)
+    end
+  end
+end

--- a/app/services/session_manipulation/set_chargeable_zones.rb
+++ b/app/services/session_manipulation/set_chargeable_zones.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetChargeableZones < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 5
+    LEVEL = 6
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_compliance_details.rb
+++ b/app/services/session_manipulation/set_compliance_details.rb
@@ -14,7 +14,7 @@ module SessionManipulation
   #
   class SetComplianceDetails < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 6
+    LEVEL = 7
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_confirm_exempt.rb
+++ b/app/services/session_manipulation/set_confirm_exempt.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Service used to confirm not locally exempt.
+  #
+  # ==== Usage
+  #    SessionManipulation::SetConfirmExempt.call(session: session)
+  #
+  class SetConfirmExempt < BaseManipulator
+    # Level used to clearing keys in the session
+    LEVEL = 9
+
+    # Sets +confirm_exempt+ to true in the session. Used by the class level method +.call+
+    def call
+      add_fields(confirm_exempt: true)
+    end
+  end
+end

--- a/app/services/session_manipulation/set_confirm_registration.rb
+++ b/app/services/session_manipulation/set_confirm_registration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Service used to confirm registration number correct.
+  #
+  # ==== Usage
+  #    SessionManipulation::SetConfirmRegistration.call(session: session)
+  #
+  class SetConfirmRegistration < BaseManipulator
+    # Level used to clearing keys in the session
+    LEVEL = 2
+
+    # Sets +confirm_registration+ to true in the session. Used by the class level method +.call+
+    def call
+      add_fields(confirm_registration: true)
+    end
+  end
+end

--- a/app/services/session_manipulation/set_confirm_vehicle.rb
+++ b/app/services/session_manipulation/set_confirm_vehicle.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Service used to confirm registration number correct.
+  #
+  # ==== Usage
+  #    SessionManipulation::SetConfirmVehicle.call(session: session, confirm_vehicle: true)
+  #
+  class SetConfirmVehicle < BaseManipulator
+    # Level used to clearing keys in the session
+    LEVEL = 3
+
+    # Initializer function. Used by the class level method +.call+
+    #
+    # ==== Attributes
+    # * +session+ - the user's session
+    # * +confirm_vehicle+ - a boolean
+    #
+    def initialize(session:, confirm_vehicle:)
+      @session = session
+      @confirm_vehicle = confirm_vehicle
+    end
+
+    # Sets +confirm_vehicle+ in the session. Used by the class level method +.call+
+    def call
+      add_fields(confirm_vehicle: @confirm_vehicle)
+    end
+  end
+end

--- a/app/services/session_manipulation/set_incorrect.rb
+++ b/app/services/session_manipulation/set_incorrect.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetIncorrect < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 4
+    LEVEL = 5
 
     # Sets +incorrect+ to true in the session. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_payment_details.rb
+++ b/app/services/session_manipulation/set_payment_details.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetPaymentDetails < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 9
+    LEVEL = 12
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_payment_id.rb
+++ b/app/services/session_manipulation/set_payment_id.rb
@@ -10,7 +10,7 @@ module SessionManipulation
   #
   class SetPaymentId < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 8
+    LEVEL = 11
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_type.rb
+++ b/app/services/session_manipulation/set_type.rb
@@ -10,7 +10,7 @@ module SessionManipulation
   #
   class SetType < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 3
+    LEVEL = 4
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_unrecognised.rb
+++ b/app/services/session_manipulation/set_unrecognised.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetUnrecognised < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 2
+    LEVEL = 3
 
     # Sets +unrecognised+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/views/charges/local_authority.html.haml
+++ b/app/views/charges/local_authority.html.haml
@@ -28,7 +28,7 @@
                                              type: 'radio',
                                              value: zone.id,
                                              id: zone.name.downcase,
-                                             checked: zone.id == session[:vehicle_details]['la_id']}
+                                             checked: zone.id == session.dig(:vehicle_details, 'la_id')}
                   %label.govuk-label.govuk-radios__label{for: zone.name.downcase}
                     = zone.name
         = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/app/views/dates/daily_charge.html.haml
+++ b/app/views/dates/daily_charge.html.haml
@@ -40,6 +40,7 @@
                 %input.govuk-checkboxes__input{name: 'confirm-exempt',
                                                type: 'checkbox',
                                                value: 'yes',
+                                               checked: session.dig(:vehicle_details, 'confirm_exempt'),
                                                id: 'confirm-exempt'}
                 %label.govuk-label.govuk-checkboxes__label{for: 'confirm-exempt'}
                   I confirm I am not exempt from paying the

--- a/app/views/dates/select_period_input/_normal.html.haml
+++ b/app/views/dates/select_period_input/_normal.html.haml
@@ -3,12 +3,14 @@
     .govuk-radios__item
       %input#period-1.govuk-radios__input{name: 'period',
                                           type: 'radio',
+                                          checked: session.dig(:vehicle_details, 'charge_period') == 'daily-charge',
                                           value: 'daily-charge'}
       %label.govuk-label.govuk-radios__label{for: 'period-1'}
         Pay for 1 day (£12.50)
     .govuk-radios__item
       %input#period-2.govuk-radios__input{name: 'period',
                                           type: 'radio',
+                                          checked: session.dig(:vehicle_details, 'charge_period') == 'weekly-charge',
                                           value: 'weekly-charge'}
       %label.govuk-label.govuk-radios__label{for: 'period-2'}
         Pay for 7 days (£50.00)

--- a/app/views/dates/weekly_charge.html.haml
+++ b/app/views/dates/weekly_charge.html.haml
@@ -41,6 +41,7 @@
                 %input.govuk-checkboxes__input{name: 'confirm-exempt',
                                                type: 'checkbox',
                                                value: 'yes',
+                                               checked: session.dig(:vehicle_details, 'confirm_exempt'),
                                                id: 'confirm-exempt'}
                 %label.govuk-label.govuk-checkboxes__label{for: 'confirm-exempt'}
                   I confirm that I am not exempt from paying the

--- a/app/views/non_dvla_vehicles/choose_type.html.haml
+++ b/app/views/non_dvla_vehicles/choose_type.html.haml
@@ -23,7 +23,7 @@
               - @types.each_with_index do |type, index|
                 - id = "vehicle-type-#{index}"
                 .govuk-radios__item
-                  %input.govuk-radios__input{name: 'vehicle-type', id: id, type: 'radio', value: type[:value]}
+                  %input.govuk-radios__input{name: 'vehicle-type', id: id, type: 'radio', checked: (session.dig(:vehicle_details, 'type') == type[:value]), value: type[:value]}
                   %label.govuk-label.govuk-radios__label{for: id}
                     = type[:name]
         = submit_tag 'Confirm', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/app/views/non_dvla_vehicles/index.html.haml
+++ b/app/views/non_dvla_vehicles/index.html.haml
@@ -1,4 +1,4 @@
-= link_to 'Back', enter_details_vehicles_path, class: 'govuk-back-link', id: 'back-link'
+= link_to 'Back', enter_details_vehicles_path + '?back=true', class: 'govuk-back-link', id: 'back-link'
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -42,6 +42,7 @@
                   %input.govuk-checkboxes__input{name: 'confirm-registration',
                                                  type: 'checkbox',
                                                  value: 'yes',
+                                                 checked: session.dig(:vehicle_details, 'confirm_registration'),
                                                  id: 'confirm-registration'}
                   %label.govuk-label.govuk-checkboxes__label{for: 'confirm-registration'}
                     I confirm the number plate is correct.

--- a/app/views/vehicles/country_input/_normal.html.haml
+++ b/app/views/vehicles/country_input/_normal.html.haml
@@ -6,13 +6,13 @@
       %input#registration-country-1.govuk-radios__input{name: 'registration-country',
                                                         type: 'radio',
                                                         value: 'UK',
-                                                        checked: params['registration-country'] == 'UK'}
+                                                        checked: session.dig(:vehicle_details, 'country') == 'UK'}
       %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
         UK
     .govuk-radios__item
       %input#registration-country-2.govuk-radios__input{name: 'registration-country',
                                                         type: 'radio',
                                                         value: 'Non-UK',
-                                                        checked: params['registration-country'] == 'Non-UK'}
+                                                        checked: session.dig(:vehicle_details, 'country') == 'Non-UK'}
       %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
         Non-UK

--- a/app/views/vehicles/details.html.haml
+++ b/app/views/vehicles/details.html.haml
@@ -48,11 +48,11 @@
 
             .govuk-radios.govuk-radios--inline
               .govuk-radios__item
-                %input#confirm-vehicle-1.govuk-radios__input{name: 'confirm-vehicle', type: 'radio', value: 'yes'}
+                %input#confirm-vehicle-1.govuk-radios__input{name: 'confirm-vehicle', type: 'radio', checked: session.dig(:vehicle_details, 'confirm_vehicle'), value: 'yes'}
                 %label.govuk-label.govuk-radios__label{for: 'confirm-vehicle-1'}
                   Yes
               .govuk-radios__item
-                %input#confirm-vehicle-2.govuk-radios__input{name: 'confirm-vehicle', type: 'radio', value: 'no'}
+                %input#confirm-vehicle-2.govuk-radios__input{name: 'confirm-vehicle', type: 'radio', checked: session.dig(:vehicle_details, 'confirm_vehicle') == false, value: 'no'}
                 %label.govuk-label.govuk-radios__label{for: 'confirm-vehicle-2'}
                   No
         = submit_tag 'Confirm', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/app/views/vehicles/unrecognised.html.haml
+++ b/app/views/vehicles/unrecognised.html.haml
@@ -59,6 +59,7 @@
                 %input.govuk-checkboxes__input{name: 'confirm-registration',
                                                type: 'checkbox',
                                                value: 'yes',
+                                               checked: session.dig(:vehicle_details, 'unrecognised'),
                                                id: 'confirm-registration'}
                 %label.govuk-label.govuk-checkboxes__label{for: 'confirm-registration'}
                   I confirm the number plate is correct.

--- a/app/views/vehicles/vrn_input/_normal.html.haml
+++ b/app/views/vehicles/vrn_input/_normal.html.haml
@@ -7,4 +7,4 @@
                                    name: 'vrn',
                                    type: 'text',
                                    maxlength: 15,
-                                   value: params[:vrn]}
+                                   value: session.dig(:vehicle_details, 'vrn')}

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -64,6 +64,10 @@ Then("I enter a exempt vehicle's registration and choose UK") do
   choose('UK')
 end
 
+Then('I should see {string} as {field} value') do |string|
+  expect(page).to have_field(field, with: string)
+end
+
 Given('I am on the vehicle details page with unrecognized vehicle to check') do
   add_vrn_and_country_to_session
   mock_unrecognized_vehicle

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -64,8 +64,8 @@ Then("I enter a exempt vehicle's registration and choose UK") do
   choose('UK')
 end
 
-Then('I should see {string} as {field} value') do |string|
-  expect(page).to have_field(field, with: string)
+Then('I should see {string} as vrn value') do |string|
+  expect(page).to have_field('vrn', with: string)
 end
 
 Given('I am on the vehicle details page with unrecognized vehicle to check') do

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -25,8 +25,10 @@ Feature: Vehicles
     Then I enter a vehicle's registration and choose UK
       And I press the Continue
       And I should see "Are these vehicle details correct?"
+    Then I press the Back link
+      Then I should see "CU57ABC" as vrn value
+      And I press the Continue
     Then I press the Confirm
-      And I should see "Select yes if the details are correct"
       And I should see "Select yes if the details are correct"
     Then I choose that the details are incorrect
       And I press the Confirm

--- a/spec/requests/vehicles_controller/unrecognised_spec.rb
+++ b/spec/requests/vehicles_controller/unrecognised_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe 'VehiclesController - GET #unrecognised', type: :request do
     expect(response).to have_http_status(:success)
   end
 
-  it 'sets unrecognised in the session' do
-    expect(session[:vehicle_details]['unrecognised']).to be_truthy
-  end
-
   it 'assigns the @vrn' do
     expect(assigns(:vrn)).to eq(vrn)
   end

--- a/spec/services/session_manipulation/clear_payment_details_spec.rb
+++ b/spec/services/session_manipulation/clear_payment_details_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe SessionManipulation::ClearPaymentDetails do
     {
       'vrn' => 'CU123AB',
       'country' => 'UK',
+      'confirm_vehicle' => true,
       'leeds_taxi' => true,
       'unrecognised' => true,
+      'confirm_registration' => true,
       'type' => 'car',
       'incorrect' => true,
       'chargeable_zones' => 2,
@@ -19,6 +21,8 @@ RSpec.describe SessionManipulation::ClearPaymentDetails do
       'daily_charge' => 12.5,
       'la_name' => 'Leeds',
       'weekly_possible' => true,
+      'tariff_code' => 'test',
+      'charge_period' => 'daily-charge',
       'dates' => ['2019-11-01'],
       'total_charge' => 50,
       'weekly' => true,
@@ -34,10 +38,13 @@ RSpec.describe SessionManipulation::ClearPaymentDetails do
     expect(session[:vehicle_details].keys).to contain_exactly(
       'vrn',
       'country',
+      'confirm_vehicle',
       'leeds_taxi',
       'unrecognised',
+      'confirm_registration',
       'type',
       'incorrect',
+      'la_id',
       'chargeable_zones'
     )
   end

--- a/spec/services/session_manipulation/set_charge_period_spec.rb
+++ b/spec/services/session_manipulation/set_charge_period_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetChargePeriod do
+  subject(:service) { described_class.call(session: session, charge_period: 'daily-period') }
+
+  let(:session) { { vehicle_details: details } }
+  let(:details) { { 'vrn' => vrn, 'country' => country } }
+  let(:vrn) { 'CU123AB' }
+  let(:country) { 'UK' }
+
+  it 'sets charge period' do
+    service
+    expect(session[:vehicle_details]['charge_period']).to eq('daily-period')
+  end
+
+  context 'when session is already filled with more data' do
+    let(:details) do
+      {
+        'vrn' => vrn,
+        'country' => country,
+        'payment_id' => SecureRandom.uuid,
+        'type' => 'Car',
+        'confirm_exempt' => true
+      }
+    end
+
+    it 'clears keys from next steps' do
+      service
+      expect(session[:vehicle_details].keys)
+        .to contain_exactly('vrn', 'country', 'type', 'charge_period')
+    end
+  end
+end

--- a/spec/services/session_manipulation/set_confirm_exempt_spec.rb
+++ b/spec/services/session_manipulation/set_confirm_exempt_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetConfirmExempt do
+  subject(:service) { described_class.call(session: session) }
+
+  let(:session) { { vehicle_details: details } }
+  let(:details) { { 'vrn' => vrn, 'country' => country } }
+  let(:vrn) { 'CU123AB' }
+  let(:country) { 'UK' }
+
+  it 'sets confirm exempt' do
+    service
+    expect(session[:vehicle_details]['confirm_exempt']).to be_truthy
+  end
+
+  context 'when session is already filled with more data' do
+    let(:details) do
+      {
+        'vrn' => vrn,
+        'country' => country,
+        'payment_id' => SecureRandom.uuid,
+        'type' => 'Car',
+        'charge_period' => 'daily-period'
+      }
+    end
+
+    it 'clears keys from next steps' do
+      service
+      expect(session[:vehicle_details].keys)
+        .to contain_exactly('vrn', 'country', 'type', 'charge_period', 'confirm_exempt')
+    end
+  end
+end

--- a/spec/services/session_manipulation/set_confirm_registration_spec.rb
+++ b/spec/services/session_manipulation/set_confirm_registration_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetConfirmRegistration do
+  subject(:service) { described_class.call(session: session) }
+
+  let(:session) { { vehicle_details: details } }
+  let(:details) { { 'vrn' => vrn, 'country' => country } }
+  let(:vrn) { 'CU123AB' }
+  let(:country) { 'UK' }
+
+  it 'sets confirm registration' do
+    service
+    expect(session[:vehicle_details]['confirm_registration']).to be_truthy
+  end
+
+  context 'when session is already filled with more data' do
+    let(:details) do
+      {
+        'vrn' => vrn,
+        'country' => country,
+        'payment_id' => SecureRandom.uuid,
+        'type' => 'Car',
+        'charge_period' => 'daily-period'
+      }
+    end
+
+    it 'clears keys from next steps' do
+      service
+      expect(session[:vehicle_details].keys)
+        .to contain_exactly('vrn', 'country', 'confirm_registration')
+    end
+  end
+end

--- a/spec/services/session_manipulation/set_confirm_vehicle_spec.rb
+++ b/spec/services/session_manipulation/set_confirm_vehicle_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetConfirmVehicle do
+  subject(:service) { described_class.call(session: session, confirm_vehicle: true) }
+
+  let(:session) { { vehicle_details: details } }
+  let(:details) { { 'vrn' => vrn, 'country' => country } }
+  let(:vrn) { 'CU123AB' }
+  let(:country) { 'UK' }
+
+  it 'sets confirm vehicle' do
+    service
+    expect(session[:vehicle_details]['confirm_vehicle']).to be_truthy
+  end
+
+  context 'when session is already filled with more data' do
+    let(:details) do
+      {
+        'vrn' => vrn,
+        'country' => country,
+        'payment_id' => SecureRandom.uuid,
+        'type' => 'Car',
+        'charge_period' => 'daily-period'
+      }
+    end
+
+    it 'clears keys from next steps' do
+      service
+      expect(session[:vehicle_details].keys)
+        .to contain_exactly('vrn', 'country', 'confirm_vehicle')
+    end
+  end
+end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->
There is a requirement to re-render the input given when the manual back links are clicked. Thus a number of new items have been added to the session to preserve responses to pages such as 'exemption confirmation' where we would not normally persist answers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
