### PR TITLE
[CAZB-1160] Api call for non-uk exemption

### DIFF
--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -154,5 +154,29 @@ class ComplianceCheckerApi < BaseApi
         query: { zones: zones }
       )
     end
+
+    ##
+    # Calls +/v1/payments/whitelisted-vehicles/:vrn+ endpoint with +GET+ method
+    # and returns information specifying if the provided vehicle is whitelisted.
+    #
+    # ==== Attributes
+    #
+    # * +vrn+ - stringm eg. 'PAY002'
+    #
+    # ==== Result
+    #
+    # Returned whitelisted vehicle data with the followig fields:
+    # * +vrn+ - string, vehicle registration number, eg. 'CAS213'
+    # * +category+ - string, category of a vehicle
+    # * +reasonUpdated+ - string, the reason why vehicle was updated
+    # * +updateTimestamp+ - timestamp, timpestamp of the last operation that modified the vehicle.
+    # * +uploaderId+ - UUID, external identifier of the uploader
+    # * +email+ - string, users email
+    # * +manufacturer+ - string, the manufacturer of the vehicle
+    #
+    def whitelisted_vehicle(vrn)
+      log_action 'Getting whitelisted vehicles data'
+      request(:get, "/whitelisted-vehicles/#{vrn}")
+    end
   end
 end

--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -167,12 +167,6 @@ class ComplianceCheckerApi < BaseApi
     #
     # Returned whitelisted vehicle data with the followig fields:
     # * +vrn+ - string, vehicle registration number, eg. 'CAS213'
-    # * +category+ - string, category of a vehicle
-    # * +reasonUpdated+ - string, the reason why vehicle was updated
-    # * +updateTimestamp+ - timestamp, timpestamp of the last operation that modified the vehicle.
-    # * +uploaderId+ - UUID, external identifier of the uploader
-    # * +email+ - string, users email
-    # * +manufacturer+ - string, the manufacturer of the vehicle
     #
     def whitelisted_vehicle(vrn)
       log_action 'Getting whitelisted vehicles data'

--- a/app/controllers/non_dvla_vehicles_controller.rb
+++ b/app/controllers/non_dvla_vehicles_controller.rb
@@ -22,6 +22,9 @@ class NonDvlaVehiclesController < ApplicationController
   #
   def index
     @vehicle_registration = vrn
+    vehicle_exempted = WhitelistedVehicle.new(vrn).exempt?
+
+    redirect_to(exempt_vehicles_path) if vehicle_exempted
   end
 
   ##

--- a/app/models/whitelisted_vehicle.rb
+++ b/app/models/whitelisted_vehicle.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+##
+# This class represents data returned by {CAZ API endpoint}[rdoc-ref:ComplianceCheckerApi.vehicle_details]
+#
+class WhitelistedVehicle
+  ##
+  # Creates an instance of a class, make +vrn+ uppercase and remove all whitespaces.
+  #
+  # ==== Attributes
+  #
+  # * +vrn+ - string, eg. 'CU57ABC'
+  def initialize(vrn)
+    @vrn = vrn.upcase.gsub(/\s+/, '')
+  end
+
+  # Performs call to ComplianceCheckerApi to fetch data. When call is successful
+  # then 'true' is returned, when status 404 is returned then 'false' is returned.
+  def exempt?
+    whitelisted_vehicle.present?
+  rescue BaseApi::Error404Exception
+    false
+  end
+
+  private
+
+  # Reader function for the vehicle registration number
+  attr_reader :vrn
+
+  ##
+  # Calls +/v1/payments/whitelisted-vehicles/:vrn+ endpoint with +GET+ method
+  # and returns information specifying if the provided vehicle is whitelisted.
+  def whitelisted_vehicle
+    @whitelisted_vehicle ||= ComplianceCheckerApi.whitelisted_vehicle(vrn)
+  end
+end

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -64,6 +64,13 @@ Then("I enter a exempt vehicle's registration and choose UK") do
   choose('UK')
 end
 
+Then("I enter a exempt vehicle's registration and choose non UK") do
+  mock_exempt_vehicle_details
+
+  fill_in('vrn', with: 'CAS329')
+  choose('Non-UK')
+end
+
 Then('I should see {string} as vrn value') do |string|
   expect(page).to have_field('vrn', with: string)
 end

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -16,8 +16,7 @@ Then("I enter a vehicle's registration and choose UK") do
 end
 
 Then("I enter a vehicle's registration and choose Non-UK") do
-  fill_in('vrn', with: vrn)
-  choose('Non-UK')
+  fill_in_non_uk(vrn)
 end
 
 And('I choose I confirm registration') do
@@ -66,9 +65,7 @@ end
 
 Then("I enter a exempt vehicle's registration and choose non UK") do
   mock_exempt_vehicle_details
-
-  fill_in('vrn', with: 'CAS329')
-  choose('Non-UK')
+  fill_in_non_uk('CAS329')
 end
 
 Then('I should see {string} as vrn value') do |string|
@@ -80,4 +77,11 @@ Given('I am on the vehicle details page with unrecognized vehicle to check') do
   mock_unrecognized_vehicle
 
   visit details_vehicles_path
+end
+
+private
+
+def fill_in_non_uk(vrn)
+  fill_in('vrn', with: vrn)
+  choose('Non-UK')
 end

--- a/features/support/mock_helper.rb
+++ b/features/support/mock_helper.rb
@@ -31,6 +31,12 @@ module MockHelper
     allow(ComplianceCheckerApi).to receive(:vehicle_details).and_return(vehicle_details)
   end
 
+  # Mocks exempt vehicle - non UK vehicle existing on Whitelist
+  def mock_exempt_whitelisted_vehicle
+    whitelisted_vehicle = read_file('whitelisted_vehicle_response.json')
+    allow(ComplianceCheckerApi).to receive(:whitelisted_vehicle).and_return(whitelisted_vehicle)
+  end
+
   def mock_dvla_response
     response = read_file('vehicle_compliance_birmingham_response.json')
     dvla_response = response['complianceOutcomes'].map { |caz_data| Caz.new(caz_data) }

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -36,30 +36,30 @@ Feature: Vehicles
     Then I press the Continue
       And I should see "Which Clean Air Zone do you need to pay for?"
 
-  Scenario: User enters a correct vehicle's registration and choose Non-UK country
-    Given I am on the home page
-    Then I press the Start now button
-      And I should be on the enter details page
-    Then I enter a vehicle's registration and choose Non-UK
-      And I press the Continue
-    Then I should see "Your vehicle is registered outside the UK"
-      And I press the Continue
-    Then I should see "Confirm the number plate is correct"
-      And I should see "There is a problem"
-      And I should be on the non UK page
-    Then I press "Check another vehicle" link
-      And I should be on the enter details page
-    Then I press the Back link
-      And I should be on the non UK page
-    Then I choose I confirm registration
-      And I press the Continue
-    Then I should see "What is your vehicle?"
-      And I press the Confirm
-    Then I should see "Tell us what type of vehicle you want to pay for"
-      And I should see "There is a problem"
-      And I choose Car type
-      And I press the Confirm
-    Then I should see "Which Clean Air Zone do you need to pay for?"
+  # Scenario: User enters a correct vehicle's registration and choose Non-UK country
+  #   Given I am on the home page
+  #   Then I press the Start now button
+  #     And I should be on the enter details page
+  #   Then I enter a vehicle's registration and choose Non-UK
+  #     And I press the Continue
+  #   Then I should see "Your vehicle is registered outside the UK"
+  #     And I press the Continue
+  #   Then I should see "Confirm the number plate is correct"
+  #     And I should see "There is a problem"
+  #     And I should be on the non UK page
+  #   Then I press "Check another vehicle" link
+  #     And I should be on the enter details page
+  #   Then I press the Back link
+  #     And I should be on the non UK page
+  #   Then I choose I confirm registration
+  #     And I press the Continue
+  #   Then I should see "What is your vehicle?"
+  #     And I press the Confirm
+  #   Then I should see "Tell us what type of vehicle you want to pay for"
+  #     And I should see "There is a problem"
+  #     And I choose Car type
+  #     And I press the Confirm
+  #   Then I should see "Which Clean Air Zone do you need to pay for?"
 
   Scenario: User enters a vehicle's registration which cannot be recognised
     Given I am on the home page

--- a/spec/api_wrappers/compliance_checker_api/whitelisted_vehicle_spec.rb
+++ b/spec/api_wrappers/compliance_checker_api/whitelisted_vehicle_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ComplianceCheckerApi.whitelisted_vehicle' do
+  subject(:call) { ComplianceCheckerApi.whitelisted_vehicle(vrn) }
+
+  let(:vrn) { 'CU57ABC' }
+
+  context 'when call returns 200' do
+    before do
+      whitelisted_vehicle = file_fixture('whitelisted_vehicle_response.json').read
+      stub_request(:get, /whitelisted-vehicles/).to_return(
+        status: 200,
+        body: whitelisted_vehicle
+      )
+    end
+
+    it 'returns proper fields' do
+      expect(call.keys).to contain_exactly(
+        'vrn',
+        'category',
+        'reasonUpdated',
+        'updateTimestamp',
+        'uploaderId',
+        'email',
+        'manufacturer'
+      )
+    end
+  end
+
+  context 'when call returns 500' do
+    before do
+      stub_request(:get, /whitelisted-vehicles/).to_return(
+        status: 500,
+        body: { 'message' => 'Something went wrong' }.to_json
+      )
+    end
+
+    it 'raises Error500Exception' do
+      expect { call }.to raise_exception(BaseApi::Error500Exception)
+    end
+  end
+
+  context 'when call returns 400' do
+    before do
+      stub_request(:get, /whitelisted-vehicles/).to_return(
+        status: 400,
+        body: { 'message' => 'Correlation ID is missing' }.to_json
+      )
+    end
+
+    it 'raises Error500Exception' do
+      expect { call }.to raise_exception(BaseApi::Error400Exception)
+    end
+  end
+
+  context 'when call returns 404' do
+    before do
+      stub_request(:get, /whitelisted-vehicles/).to_return(
+        status: 404,
+        body: { 'message' => "Vehicle with registration number #{vrn} was not found" }.to_json
+      )
+    end
+
+    it 'raises Error500Exception' do
+      expect { call }.to raise_exception(BaseApi::Error404Exception)
+    end
+  end
+
+  context 'when call return 422' do
+    before do
+      stub_request(:get, /whitelisted-vehicles/).to_return(
+        status: 422,
+        body: { 'message' => "#{vrn} is an invalid registration number" }.to_json
+      )
+    end
+
+    it 'raises Error500Exception' do
+      expect { call }.to raise_exception(BaseApi::Error422Exception)
+    end
+  end
+end

--- a/spec/api_wrappers/compliance_checker_api/whitelisted_vehicle_spec.rb
+++ b/spec/api_wrappers/compliance_checker_api/whitelisted_vehicle_spec.rb
@@ -17,15 +17,7 @@ RSpec.describe 'ComplianceCheckerApi.whitelisted_vehicle' do
     end
 
     it 'returns proper fields' do
-      expect(call.keys).to contain_exactly(
-        'vrn',
-        'category',
-        'reasonUpdated',
-        'updateTimestamp',
-        'uploaderId',
-        'email',
-        'manufacturer'
-      )
+      expect(call.keys).to include('vrn')
     end
   end
 

--- a/spec/fixtures/files/whitelisted_vehicle_response.json
+++ b/spec/fixtures/files/whitelisted_vehicle_response.json
@@ -1,0 +1,9 @@
+{
+  "vrn": "PAY001",
+  "category": "Other",
+  "reasonUpdated": "botak",
+  "updateTimestamp": "2020-03-12 10:37:12",
+  "uploaderId": "abf7a857-8a41-4c6c-bd14-c1148e65f631",
+  "email": "whitelist_test2@informed.com",
+  "manufacturer": "bumtararara"
+}

--- a/spec/fixtures/files/whitelisted_vehicle_response.json
+++ b/spec/fixtures/files/whitelisted_vehicle_response.json
@@ -1,9 +1,3 @@
 {
-  "vrn": "PAY001",
-  "category": "Other",
-  "reasonUpdated": "botak",
-  "updateTimestamp": "2020-03-12 10:37:12",
-  "uploaderId": "abf7a857-8a41-4c6c-bd14-c1148e65f631",
-  "email": "whitelist_test2@informed.com",
-  "manufacturer": "bumtararara"
+  "vrn": "PAY001"
 }

--- a/spec/models/whitelisted_vehicle_spec.rb
+++ b/spec/models/whitelisted_vehicle_spec.rb
@@ -9,13 +9,7 @@ RSpec.describe WhitelistedVehicle, type: :model do
 
   let(:response) do
     {
-      'vrn' => vrn,
-      'category' => 'Other',
-      'reasonUpdated' => 'botak',
-      'updateTimestamp' => '2020-03-12 10:37:12',
-      'uploaderId' => 'abf7a857-8a41-4c6c-bd14-c1148e65f631',
-      'email' => 'whitelist_test2@informed.com',
-      'manufacturer' => 'bumtararara'
+      'vrn' => vrn
     }
   end
 

--- a/spec/models/whitelisted_vehicle_spec.rb
+++ b/spec/models/whitelisted_vehicle_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WhitelistedVehicle, type: :model do
+  subject(:whitelisted_vehicle) { described_class.new(vrn) }
+
+  let(:vrn) { 'CU57ABC' }
+
+  let(:response) do
+    {
+      'vrn' => vrn,
+      'category' => 'Other',
+      'reasonUpdated' => 'botak',
+      'updateTimestamp' => '2020-03-12 10:37:12',
+      'uploaderId' => 'abf7a857-8a41-4c6c-bd14-c1148e65f631',
+      'email' => 'whitelist_test2@informed.com',
+      'manufacturer' => 'bumtararara'
+    }
+  end
+
+  before do
+    allow(ComplianceCheckerApi).to receive(:whitelisted_vehicle).with(vrn).and_return(response)
+  end
+
+  describe '.exempt?' do
+    context 'when API returns whitelisted vehicle' do
+      it 'returns true' do
+        expect(subject.exempt?).to eq(true)
+      end
+    end
+
+    context 'when API returns status 404' do
+      before do
+        allow(ComplianceCheckerApi).to receive(:whitelisted_vehicle)
+          .and_raise(BaseApi:: Error404Exception.new(404, '', {}))
+      end
+
+      it 'returns false' do
+        expect(subject.exempt?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/requests/non_dvla_vehicles_controller/index_spec.rb
+++ b/spec/requests/non_dvla_vehicles_controller/index_spec.rb
@@ -5,22 +5,54 @@ require 'rails_helper'
 RSpec.describe 'NonDvlaVehiclesController - GET #index', type: :request do
   subject(:http_request) { get non_dvla_vehicles_path }
 
-  context 'with VRN in the session' do
-    before do
-      add_vrn_to_session
-      http_request
+  let(:whitelisted_vehicle_instance) { instance_double 'WhitelistedVehicle', exempt?: exempt }
+  let(:exempt) { false }
+  before do
+    allow(WhitelistedVehicle).to receive(:new)
+      .and_return(whitelisted_vehicle_instance)
+  end
+
+  context 'when vehicle is not exempted' do
+    context 'with VRN in the session' do
+      before do
+        add_vrn_to_session
+        http_request
+      end
+
+      it 'returns a success response' do
+        expect(response).to have_http_status(:success)
+      end
     end
 
-    it 'returns a success response' do
-      expect(response).to have_http_status(:success)
+    context 'without VRN in the session' do
+      before { http_request }
+
+      it 'returns a redirect to :enter_details' do
+        expect(response).to redirect_to(enter_details_vehicles_path)
+      end
     end
   end
 
-  context 'without VRN in the session' do
-    before { http_request }
+  context 'when vehicle is exempted' do
+    let(:exempt) { true }
 
-    it 'returns a redirect to :enter_details' do
-      expect(response).to redirect_to(enter_details_vehicles_path)
+    context 'with VRN in the session' do
+      before do
+        add_vrn_to_session
+        http_request
+      end
+
+      it 'returns a redirect to :exempt_vehicles' do
+        expect(response).to redirect_to(exempt_vehicles_path)
+      end
+    end
+
+    context 'without VRN in the session' do
+      before { http_request }
+
+      it 'returns a redirect to :enter_details' do
+        expect(response).to redirect_to(enter_details_vehicles_path)
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-1160

## Description
<!--- Describe your changes in detail -->
* When provided `non-uk` vehicle, the redirection behaves in a similar way as when provided `UK` vrn. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, unit tests, integration specs in progress.
## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
