### PR TITLE
[CAZ-2111] Fix Payment for Undetermined vehicle.

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -138,7 +138,7 @@ class ChargesController < ApplicationController
 
   # Redirects to 'Unable to determine compliance' page
   def unable_to_determine_compliance
-    SessionManipulation::SetUnrecognised.call(session: session)
+    SessionManipulation::SetUndetermined.call(session: session)
 
     redirect_to not_determined_vehicles_path
   end

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -263,13 +263,8 @@ class VehiclesController < ApplicationController
 
   # back button paths on enter details page
   def back_button_paths
-    [
-      non_dvla_vehicles_path,
-      incorrect_details_vehicles_path,
-      unrecognised_vehicles_path,
-      compliant_vehicles_path,
-      exempt_vehicles_path
-    ]
+    [non_dvla_vehicles_path, incorrect_details_vehicles_path, unrecognised_vehicles_path,
+     compliant_vehicles_path, exempt_vehicles_path]
   end
 
   # persists whether or not vehicle details are correct into session and returns correct onward path

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -68,6 +68,7 @@ class VehiclesController < ApplicationController
 
     SessionManipulation::SetLeedsTaxi.call(session: session) if @vehicle_details.leeds_taxi?
     SessionManipulation::SetType.call(session: session, type: @vehicle_details.type)
+    SessionManipulation::SetUndetermined.call(session: session) if @vehicle_details.undetermined?
   end
 
   ##
@@ -274,6 +275,13 @@ class VehiclesController < ApplicationController
   # persists whether or not vehicle details are correct into session and returns correct onward path
   def process_detail_form(form)
     SessionManipulation::SetConfirmVehicle.call(session: session, confirm_vehicle: form.confirmed?)
-    form.confirmed? ? local_authority_charges_path : incorrect_details_vehicles_path
+    return incorrect_details_vehicles_path unless form.confirmed?
+
+    confirmed_undetermined? ? not_determined_vehicles_path : local_authority_charges_path
+  end
+
+  # check if user confirmed details for undetermined vehicle
+  def confirmed_undetermined?
+    session['vehicle_details']['undetermined'].present?
   end
 end

--- a/app/models/compliance_details.rb
+++ b/app/models/compliance_details.rb
@@ -19,7 +19,8 @@ class ComplianceDetails
     @vrn = vehicle_details['vrn']
     @type = (vehicle_details['type'] || '').downcase
     @zone_id = vehicle_details['la_id']
-    @non_dvla = vehicle_details['country'] != 'UK' || vehicle_details['unrecognised']
+    @non_dvla = vehicle_details['country'] != 'UK' || vehicle_details['unrecognised'] ||
+                vehicle_details['undetermined']
     @leeds_taxi = vehicle_details['leeds_taxi'] || false
   end
 

--- a/app/models/vehicle_details.rb
+++ b/app/models/vehicle_details.rb
@@ -49,12 +49,12 @@ class VehicleDetails
 
   # Check if type is 'null'
   #
-  # Returns a string 'true' if type is 'null' or is empty.
-  # Returns a string 'false' if type is not 'null'.
+  # Returns a boolean true if type is 'null' or is empty.
+  # Returns a boolean false if type is not 'null'.
   def undetermined?
-    return 'true' if compliance_api['type'].blank?
+    return true if compliance_api['type'].blank?
 
-    (compliance_api['type']&.downcase == 'null').to_s
+    (compliance_api['type']&.downcase == 'null')
   end
 
   # Returns a string, eg. 'M1'.

--- a/app/services/chargeable_zones_service.rb
+++ b/app/services/chargeable_zones_service.rb
@@ -18,7 +18,8 @@ class ChargeableZonesService < BaseService
   def initialize(vehicle_details:)
     @vrn = vehicle_details['vrn']
     @type = vehicle_details['type']
-    @non_dvla = vehicle_details['country'] != 'UK' || vehicle_details['unrecognised']
+    @non_dvla = vehicle_details['country'] != 'UK' || vehicle_details['unrecognised'] ||
+                vehicle_details['undetermined']
   end
 
   # The caller method for the service.

--- a/app/services/session_manipulation/base_manipulator.rb
+++ b/app/services/session_manipulation/base_manipulator.rb
@@ -14,7 +14,7 @@ module SessionManipulation
     # Subkeys of vehicle values in order of setting
     SUBKEYS = {
       1 => %w[vrn country confirm_vehicle],
-      2 => %w[unrecognised leeds_taxi confirm_registration],
+      2 => %w[unrecognised leeds_taxi confirm_registration undetermined],
       3 => %w[confirm_vehicle],
       4 => %w[type],
       5 => %w[incorrect la_id],

--- a/app/services/session_manipulation/set_undetermined.rb
+++ b/app/services/session_manipulation/set_undetermined.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Service used to mark vehicle as undetermined in the DVLA database.
+  #
+  # ==== Usage
+  #    SessionManipulation::SetUndetermined.call(session: session)
+  #
+  class SetUndetermined < BaseManipulator
+    # Level used to clearing keys in the session
+    LEVEL = 2
+
+    # Sets +undetermined+ to true in the session. Used by the class level method +.call+
+    def call
+      add_fields(undetermined: true)
+    end
+  end
+end

--- a/app/views/vehicles/enter_details.html.haml
+++ b/app/views/vehicles/enter_details.html.haml
@@ -21,6 +21,9 @@
         = title_and_header
       = form_tag enter_details_vehicles_path, method: :post do
         %fieldset.govuk-fieldset
+          %legend.govuk-visually-hidden
+            = title_and_header
+
           - if @errors[:vrn].present?
             = render 'vehicles/vrn_input/errored', message: @errors[:vrn].first
           - else

--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -23,6 +23,13 @@ Then("I enter an incomplete vehicle's registration and choose UK") do
   choose('UK')
 end
 
+Then("I enter an undetermined vehicle's registration and choose UK") do
+  mock_undetermined_vehicle_details
+
+  fill_in('vrn', with: vrn)
+  choose('UK')
+end
+
 Then("I enter an exempted non-UK vehicle's registration") do
   mock_exempt_whitelisted_vehicle
   fill_in_non_uk(vrn)

--- a/features/support/mock_helper.rb
+++ b/features/support/mock_helper.rb
@@ -25,6 +25,14 @@ module MockHelper
       .and_return(vehicle_details)
   end
 
+  # Mocks response from vehicle details endpoint in VCCS API
+  def mock_undetermined_vehicle_details
+    vehicle_details = read_file('undetermined_vehicle_details_response.json')
+    allow(ComplianceCheckerApi)
+      .to receive(:vehicle_details)
+      .and_return(vehicle_details)
+  end
+
   # Mocks exempt vehicle details endpoint in VCCS API
   def mock_exempt_vehicle_details
     vehicle_details = read_file('vehicle_details_exempt_response.json')

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -116,11 +116,26 @@ Feature: Vehicles
     Then I press "Back" link
       And I should be on the unrecognised page
 
-  Scenario: User wants to pay for incomplete vehicle
+  Scenario: User wants to pay for incomplete (not able to get compliance from VCCS) vehicle
     Given I am on the home page
       Then I press the Start now button
         And I should be on the enter details page
       Then I enter an incomplete vehicle's registration and choose UK
+        And I press the Continue
+        And I should see "Are these vehicle details correct?"
+      Then I choose that the details are correct
+        And I press the Confirm
+        And I should see "Vehicle details are incomplete"
+        And I should see "What is your vehicle?"
+        And I choose Car type
+        And I press the Confirm
+      Then I should see "Which Clean Air Zone do you need to pay for?"
+
+  Scenario: User wants to pay for undetermined (without type) vehicle
+    Given I am on the home page
+      Then I press the Start now button
+        And I should be on the enter details page
+      Then I enter an undetermined vehicle's registration and choose UK
         And I press the Continue
         And I should see "Are these vehicle details correct?"
       Then I choose that the details are correct

--- a/spec/fixtures/files/undetermined_vehicle_details_response.json
+++ b/spec/fixtures/files/undetermined_vehicle_details_response.json
@@ -1,0 +1,9 @@
+{
+  "registration_number": "CU57ABC",
+  "typeApproval": "M1",
+  "make": "Peugeot",
+  "model": "208",
+  "colour": "grey",
+  "fuelType": "diesel",
+  "taxiOrPhv": false
+}

--- a/spec/models/vehicle_details_spec.rb
+++ b/spec/models/vehicle_details_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe VehicleDetails, type: :model do
 
   describe '.undetermined?' do
     it 'returns a proper type approval' do
-      expect(subject.undetermined?).to eq('false')
+      expect(subject.undetermined?).to eq(false)
     end
 
     context 'when key is not present' do
@@ -142,7 +142,7 @@ RSpec.describe VehicleDetails, type: :model do
       end
 
       it 'returns a nil' do
-        expect(compliance.undetermined?).to eq('true')
+        expect(compliance.undetermined?).to eq(true)
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe VehicleDetails, type: :model do
       let(:type) { ' ' }
 
       it 'returns a nil' do
-        expect(compliance.undetermined?).to eq('true')
+        expect(compliance.undetermined?).to eq(true)
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe VehicleDetails, type: :model do
       let(:type) { 'null' }
 
       it 'returns a nil' do
-        expect(compliance.undetermined?).to eq('true')
+        expect(compliance.undetermined?).to eq(true)
       end
     end
   end

--- a/spec/services/session_manipulation/set_undetermined_spec.rb
+++ b/spec/services/session_manipulation/set_undetermined_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetUndetermined do
+  subject(:service) { described_class.call(session: session) }
+
+  let(:session) { { vehicle_details: details } }
+  let(:details) { { 'vrn' => vrn, 'country' => country } }
+  let(:vrn) { 'CU123AB' }
+  let(:country) { 'UK' }
+
+  it 'sets undetermined' do
+    service
+    expect(session[:vehicle_details]['undetermined']).to be_truthy
+  end
+
+  context 'when session is already filled with more data' do
+    let(:details) do
+      {
+        'vrn' => vrn,
+        'country' => country,
+        'payment_id' => SecureRandom.uuid,
+        'type' => 'Car',
+        'taxi' => true
+      }
+    end
+
+    it 'clears keys from next steps' do
+      service
+      expect(session[:vehicle_details].keys)
+        .to contain_exactly('vrn', 'country', 'undetermined')
+    end
+  end
+end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2111
Fix Payment process for a vehicle without type where compliance returns 200 status

## Description
<!--- Describe your changes in detail -->
Added the edge case when the details do not contain TYPE but compliance returns 200 instead of 422. 

## How Has This Been Tested?
Tested with many vrns (for example PAY017, TST009, TST010, TST011, CAS309)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
