### PR TITLE
[CAZ-2708] Removed non-chargeable CAZes from CAZ selection page

### DIFF
--- a/features/step_definitions/vehicle_steps.rb
+++ b/features/step_definitions/vehicle_steps.rb
@@ -100,6 +100,13 @@ Given('I am on the vehicle details page with unrecognized vehicle to check') do
   visit details_vehicles_path
 end
 
+Then("I enter a vehicle's registration but the zones are not active") do
+  mock_non_chargeable_zones
+  mock_vehicle_details
+  fill_in('vrn', with: 'CAS310')
+  choose('UK')
+end
+
 private
 
 def fill_in_non_uk(vrn)

--- a/features/support/mock_helper.rb
+++ b/features/support/mock_helper.rb
@@ -89,6 +89,12 @@ module MockHelper
       .and_raise(BaseApi::Error404Exception.new(404, '', {}))
   end
 
+  # Mocks response from clean-air-zones with in VCCS API with non active zones
+  def mock_non_chargeable_zones
+    caz_list = read_file('unchargeable_caz_list_response.json')
+    allow(ComplianceCheckerApi).to receive(:clean_air_zones).and_return(caz_list['cleanAirZones'])
+  end
+
   def mock_payment_creation
     allow(Payment).to receive(:new).and_return(
       OpenStruct.new(payment_id: SecureRandom.uuid, gov_uk_pay_url: gov_uk_pay_url)

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -151,6 +151,17 @@ Feature: Vehicles
         And I press the Confirm
       Then I should see 'Which Clean Air Zone do you need to pay for?'
 
+  Scenario: User wants to pay for non active Clean Air Zone
+    Given I am on the home page
+      Then I press the Start now button
+        And I should be on the enter details page
+    Then I enter a vehicle's registration but the zones are not active
+      And I press the Continue
+      And I should see 'Are these vehicle details correct?'
+    Then I choose that the details are correct
+      And I press the Confirm
+      And I should see 'There is no charge for this vehicle'
+
   Scenario: User wants to pay for undetermined (without type) incorrect vehicle
     Given I am on the home page
       Then I press the Start now button

--- a/spec/api_wrappers/compliance_checker_api/clean_air_zones_spec.rb
+++ b/spec/api_wrappers/compliance_checker_api/clean_air_zones_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'ComplianceCheckerApi.clean_air_zones' do
       expect(call.first.keys).to contain_exactly(
         'cleanAirZoneId',
         'name',
-        'boundaryUrl'
+        'boundaryUrl',
+        'activeChargeStartDate'
       )
     end
   end

--- a/spec/fixtures/files/unchargeable_caz_list_response.json
+++ b/spec/fixtures/files/unchargeable_caz_list_response.json
@@ -4,14 +4,13 @@
       "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a520",
       "name": "Birmingham",
       "boundaryUrl": "https://www.birmingham.gov.uk/info/20076/pollution/1763/a_clean_air_zone_for_birmingham/3",
-      "activeChargeStartDate": "2019-05-14"
-
+      "activeChargeStartDate": "2099-05-14"
     },
     {
       "cleanAirZoneId": "7d0c4240-1618-446b-bde2-2f3458c8a521",
       "name": "Leeds",
       "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-      "activeChargeStartDate": "2019-05-14"
+      "activeChargeStartDate": "2099-05-14"
     }
   ]
 }

--- a/spec/services/chargeable_zones_service_spec.rb
+++ b/spec/services/chargeable_zones_service_spec.rb
@@ -19,79 +19,102 @@ RSpec.describe ChargeableZonesService do
   let(:unrecognised) { false }
   let(:type) { nil }
 
-  before { mock_chargeable_zones }
+  context 'when zones are not chargeable' do
+    before do
+      allow(ComplianceCheckerApi).to receive(:vehicle_compliance)
 
-  context 'when country is UK' do
-    context 'and charge price is more then zero for many CAZes' do
-      before { mock_vehicle_compliance }
+      mock_non_chargeable_zones
+      mock_vehicle_compliance
+    end
+
+    it 'calls ComplianceCheckerApi.clean_air_zones' do
+      expect(ComplianceCheckerApi).to receive(:clean_air_zones)
+      service_call
+    end
+
+    it 'does not call ComplianceCheckerApi.vehicle_compliance' do
+      expect(ComplianceCheckerApi).not_to receive(:vehicle_compliance)
+      service_call
+    end
+
+    it 'returns empty CAZes collection' do
+      expect(service_call.length).to eq(0)
+    end
+  end
+
+  context 'when zones are chargeable' do
+    before { mock_chargeable_zones }
+
+    context 'when country is UK' do
+      context 'and charge price is more then zero for many CAZes' do
+        before { mock_vehicle_compliance }
+
+        it_behaves_like 'a chargeable zones service'
+
+        it 'calls ComplianceCheckerApi.vehicle_compliance with the right params' do
+          expect(ComplianceCheckerApi).to receive(:vehicle_compliance).with(vrn, mocked_zone_ids)
+          service_call
+        end
+      end
+
+      context 'and charge price is more then zero for one CAZ' do
+        before { mock_private_car_compliance }
+
+        it_behaves_like 'a chargeable zones service', 1
+      end
+
+      context 'and charge price equals to zero in all CAZes' do
+        before { mock_vehicle_with_zero_charge }
+
+        it 'returns zero caz zones' do
+          expect(service_call).to be_empty
+        end
+      end
+    end
+
+    context 'when country is Non-UK' do
+      let(:country) { 'Non-UK' }
+      let(:type) { 'private_car' }
+      let(:one_charge) { false }
+
+      before do
+        mock_chargeable_zones
+        mock_unrecognised_compliance(one_charge)
+      end
 
       it_behaves_like 'a chargeable zones service'
 
-      it 'calls ComplianceCheckerApi.vehicle_compliance with the right params' do
+      it 'calls ComplianceCheckerApi.unrecognised_compliance with the right params' do
         expect(ComplianceCheckerApi)
-          .to receive(:vehicle_compliance)
-          .with(vrn, mocked_zone_ids)
+          .to receive(:unrecognised_compliance)
+          .with(type, mocked_zone_ids)
         service_call
       end
-    end
 
-    context 'and charge price is more then zero for one CAZ' do
-      before { mock_private_car_compliance }
+      context 'when charge for one CAZ equals 0' do
+        let(:one_charge) { true }
 
-      it_behaves_like 'a chargeable zones service', 1
-    end
-
-    context 'and charge price equals to zero in all CAZes' do
-      before { mock_vehicle_with_zero_charge }
-
-      it 'returns zero caz zones' do
-        expect(service_call).to be_empty
+        it_behaves_like 'a chargeable zones service', 1
       end
     end
-  end
 
-  context 'when country is Non-UK' do
-    let(:country) { 'Non-UK' }
-    let(:type) { 'private_car' }
-    let(:one_charge) { false }
+    context 'when vehicle is unrecognised' do
+      let(:unrecognised) { true }
+      let(:type) { 'private_car' }
 
-    before do
-      mock_chargeable_zones
-      mock_unrecognised_compliance(one_charge)
-    end
+      before do
+        mock_vehicle_compliance
+        mock_unrecognised_compliance
+      end
 
-    it_behaves_like 'a chargeable zones service'
+      it_behaves_like 'a chargeable zones service'
 
-    it 'calls ComplianceCheckerApi.unrecognised_compliance with the right params' do
-      expect(ComplianceCheckerApi)
-        .to receive(:unrecognised_compliance)
-        .with(type, mocked_zone_ids)
-      service_call
-    end
-
-    context 'when charge for one CAZ equals 0' do
-      let(:one_charge) { true }
-
-      it_behaves_like 'a chargeable zones service', 1
-    end
-  end
-
-  context 'when vehicle is unrecognised' do
-    let(:unrecognised) { true }
-    let(:type) { 'private_car' }
-
-    before do
-      mock_vehicle_compliance
-      mock_unrecognised_compliance
-    end
-
-    it_behaves_like 'a chargeable zones service'
-
-    it 'calls ComplianceCheckerApi.unrecognised_compliance with the right params' do
-      expect(ComplianceCheckerApi)
-        .to receive(:unrecognised_compliance)
-        .with(type, mocked_zone_ids)
-      service_call
+      it 'calls ComplianceCheckerApi.unrecognised_compliance with the right params' do
+        expect(ComplianceCheckerApi)
+          .to receive(:unrecognised_compliance)
+          .with(type, mocked_zone_ids)
+        service_call
+      end
     end
   end
 end

--- a/spec/support/api_mocks.rb
+++ b/spec/support/api_mocks.rb
@@ -21,6 +21,12 @@ module ApiMocks
     allow(ComplianceCheckerApi).to receive(:clean_air_zones).and_return(caz_list['cleanAirZones'])
   end
 
+  # Mocks response from clean-air-zones with in VCCS API with non active zones
+  def mock_non_chargeable_zones
+    caz_list = read_file('unchargeable_caz_list_response.json')
+    allow(ComplianceCheckerApi).to receive(:clean_air_zones).and_return(caz_list['cleanAirZones'])
+  end
+
   # Mocks response from compliance endpoint in VCCS API
   def mock_vehicle_compliance
     compliance_data = read_file('vehicle_compliance_many_charges_response.json')


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2708

## Description
<!--- Describe your changes in detail -->
* Updated `ChargeableZonesService` to consider also the `active_charge_start_date` parameter when selecting the chargeable CAZes
* Updated specs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Set `active_charge_start_date` on sample cleanAirZone to be in the future.
* Click through the flow:
    * Payments UI main page
    * `Start Now >`
    * Insert VRN which is not whitelisted/exempted
    * Select UK or non-UK - doesn't matter
    * Confirm vehicle details
    * On the `Which Clean Air Zone do you need to pay for?` page, the sample cleanAirZone should not be visible.


## Screenshots (if appropriate):
* When all CAZes are chargeable:
![Screenshot 2020-05-21 at 15 23 52](https://user-images.githubusercontent.com/4506633/82567151-450e3e00-9b7d-11ea-8cd2-8e0d45608883.png)

* When one CAZ is chargeable:
![Screenshot 2020-05-21 at 15 23 00](https://user-images.githubusercontent.com/4506633/82567175-4dff0f80-9b7d-11ea-8f91-dd1b9e14d0d0.png)

* When no CAZes are chargeable:
![Screenshot 2020-05-21 at 15 23 31](https://user-images.githubusercontent.com/4506633/82567195-56574a80-9b7d-11ea-97de-fe2d6f1015b7.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
