### PR TITLE
[CAZ-2847] Disable calendar in Leeds weekly selection when JS is disabled

### DIFF
--- a/app/javascript/styles/datepicker.scss
+++ b/app/javascript/styles/datepicker.scss
@@ -12,6 +12,7 @@ body:not(.js-enabled) .litepicker-input-container {
     top: 5px;
     position: relative;
     cursor: pointer;
+
     &:before {
       content: $fa-calendar-alt-content;
       font-style: normal;
@@ -26,6 +27,7 @@ body:not(.js-enabled) .litepicker-input-container {
 
     &.is-start-date {
       cursor: pointer;
+
       &:focus,
       &:active {
         color: govuk-colour($colour: "white") !important;

--- a/app/javascript/styles/datepicker.scss
+++ b/app/javascript/styles/datepicker.scss
@@ -2,13 +2,16 @@ $fa-calendar-alt-content: "\f073";
 $highlight-start-date-color: #2196f3;
 $today-color: #f44336;
 
+body:not(.js-enabled) .litepicker-input-container {
+  display: none;
+}
+
 .far {
   &.fa-calendar-alt {
     font-size: 2.4rem;
     top: 5px;
     position: relative;
-    cursor: default;
-
+    cursor: pointer;
     &:before {
       content: $fa-calendar-alt-content;
       font-style: normal;
@@ -22,6 +25,7 @@ $today-color: #f44336;
     transition: color 0ms !important;
 
     &.is-start-date {
+      cursor: pointer;
       &:focus,
       &:active {
         color: govuk-colour($colour: "white") !important;

--- a/app/views/dates/select_weekly_date_input/_normal.html.haml
+++ b/app/views/dates/select_weekly_date_input/_normal.html.haml
@@ -23,7 +23,7 @@
                                                                               name: 'date_year',
                                                                               pattern: '^[0-9]{4}$',
                                                                               inputmode: 'numeric'}
-  .govuk-date-input__item
+  .govuk-date-input__item.litepicker-input-container
     %label.sm-visually-hidden
       Date picker for start date
     %i#litepicker.far.fa-calendar-alt


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2847

## Description
Disable calendar icon when javascript is disabled on Leeds Taxi weekly selection

## How Has This Been Tested?
Manually, by checking after js being disabled

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
