### PR TITLE
[CAZ-2860] Fix remember Non-Uk selection for fraud process

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -101,7 +101,7 @@ class PaymentsController < ApplicationController
 
   # Clears details of the payment in the session
   def clear_payment_in_session
-    SessionManipulation::ClearSessionDetails.call(session: session, key: 13)
+    SessionManipulation::ClearSessionDetails.call(session: session, key: 14)
   end
 
   # Save payment details using SessionManipulation::SetPaymentDetails

--- a/app/services/session_manipulation/base_manipulator.rb
+++ b/app/services/session_manipulation/base_manipulator.rb
@@ -25,10 +25,6 @@ module SessionManipulation
       10 => %w[confirm_exempt],
       11 => %w[confirm_weekly_charge_today weekly_dates weekly_charge_today],
       12 => %w[confirm_weekly_charge_today weekly_dates weekly_charge_today],
-
-
-
-      
       13 => %w[dates total_charge weekly],
       14 => %w[payment_id],
       15 => %w[user_email payment_reference external_id]

--- a/app/services/session_manipulation/base_manipulator.rb
+++ b/app/services/session_manipulation/base_manipulator.rb
@@ -14,19 +14,24 @@ module SessionManipulation
     # Subkeys of vehicle values in order of setting
     SUBKEYS = {
       1 => %w[vrn country confirm_vehicle],
-      2 => %w[unrecognised leeds_taxi confirm_registration undetermined possible_fraud],
-      3 => %w[confirm_vehicle incorrect],
-      4 => %w[type],
-      5 => %w[la_id],
-      6 => %w[chargeable_zones],
-      7 => %w[daily_charge la_name weekly_possible tariff_code],
-      8 => %w[charge_period],
-      9 => %w[confirm_exempt],
-      10 => %w[confirm_weekly_charge_today weekly_dates weekly_charge_today],
+      2 => %w[possible_fraud],
+      3 => %w[unrecognised leeds_taxi confirm_registration undetermined],
+      4 => %w[confirm_vehicle incorrect],
+      5 => %w[type],
+      6 => %w[la_id],
+      7 => %w[chargeable_zones],
+      8 => %w[daily_charge la_name weekly_possible tariff_code],
+      9 => %w[charge_period],
+      10 => %w[confirm_exempt],
       11 => %w[confirm_weekly_charge_today weekly_dates weekly_charge_today],
-      12 => %w[dates total_charge weekly],
-      13 => %w[payment_id],
-      14 => %w[user_email payment_reference external_id]
+      12 => %w[confirm_weekly_charge_today weekly_dates weekly_charge_today],
+
+
+
+      
+      13 => %w[dates total_charge weekly],
+      14 => %w[payment_id],
+      15 => %w[user_email payment_reference external_id]
     }.freeze
 
     # Base initializer for the service

--- a/app/services/session_manipulation/calculate_total_charge.rb
+++ b/app/services/session_manipulation/calculate_total_charge.rb
@@ -11,7 +11,7 @@ module SessionManipulation
   #
   class CalculateTotalCharge < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 12
+    LEVEL = 13
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_charge_period.rb
+++ b/app/services/session_manipulation/set_charge_period.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetChargePeriod < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 8
+    LEVEL = 9
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_chargeable_zones.rb
+++ b/app/services/session_manipulation/set_chargeable_zones.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetChargeableZones < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 6
+    LEVEL = 7
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_compliance_details.rb
+++ b/app/services/session_manipulation/set_compliance_details.rb
@@ -14,7 +14,7 @@ module SessionManipulation
   #
   class SetComplianceDetails < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 7
+    LEVEL = 8
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_confirm_exempt.rb
+++ b/app/services/session_manipulation/set_confirm_exempt.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetConfirmExempt < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 9
+    LEVEL = 10
 
     # Sets +confirm_exempt+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/services/session_manipulation/set_confirm_registration.rb
+++ b/app/services/session_manipulation/set_confirm_registration.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetConfirmRegistration < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 2
+    LEVEL = 3
 
     # Sets +confirm_registration+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/services/session_manipulation/set_confirm_vehicle.rb
+++ b/app/services/session_manipulation/set_confirm_vehicle.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetConfirmVehicle < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 3
+    LEVEL = 4
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_confirm_weekly_charge_today.rb
+++ b/app/services/session_manipulation/set_confirm_weekly_charge_today.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetConfirmWeeklyChargeToday < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 11
+    LEVEL = 12
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_incorrect.rb
+++ b/app/services/session_manipulation/set_incorrect.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetIncorrect < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 3
+    LEVEL = 4
 
     # Sets +incorrect+ to true in the session. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_leeds_taxi.rb
+++ b/app/services/session_manipulation/set_leeds_taxi.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetLeedsTaxi < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 2
+    LEVEL = 3
 
     # Sets +leeds_taxi+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/services/session_manipulation/set_payment_details.rb
+++ b/app/services/session_manipulation/set_payment_details.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetPaymentDetails < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 14
+    LEVEL = 15
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_payment_id.rb
+++ b/app/services/session_manipulation/set_payment_id.rb
@@ -10,7 +10,7 @@ module SessionManipulation
   #
   class SetPaymentId < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 13
+    LEVEL = 14
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_type.rb
+++ b/app/services/session_manipulation/set_type.rb
@@ -10,7 +10,7 @@ module SessionManipulation
   #
   class SetType < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 4
+    LEVEL = 5
 
     # Initializer function. Used by the class level method +.call+
     #

--- a/app/services/session_manipulation/set_undetermined.rb
+++ b/app/services/session_manipulation/set_undetermined.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetUndetermined < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 2
+    LEVEL = 3
 
     # Sets +undetermined+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/services/session_manipulation/set_unrecognised.rb
+++ b/app/services/session_manipulation/set_unrecognised.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetUnrecognised < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 3
+    LEVEL = 4
 
     # Sets +unrecognised+ to true in the session. Used by the class level method +.call+
     def call

--- a/app/services/session_manipulation/set_weekly_charge_today.rb
+++ b/app/services/session_manipulation/set_weekly_charge_today.rb
@@ -9,7 +9,7 @@ module SessionManipulation
   #
   class SetWeeklyChargeToday < BaseManipulator
     # Level used to clearing keys in the session
-    LEVEL = 11
+    LEVEL = 12
 
     # Initializer function
     #

--- a/app/views/vehicles/country_input/_normal.html.haml
+++ b/app/views/vehicles/country_input/_normal.html.haml
@@ -4,18 +4,17 @@
       %legend.govuk-legend
         %h2.govuk-heading-m{for: 'country-of-registration'}
           Country of registration
-
     .govuk-radios__item
       %input#registration-country-1.govuk-radios__input{name: 'registration-country',
                                                         type: 'radio',
                                                         value: 'UK',
-                                                        checked: session.dig(:vehicle_details, 'country') == 'UK'}
+                                                        checked: session.dig(:vehicle_details, 'country') == 'UK' && session.dig(:vehicle_details, 'possible_fraud') != true}
       %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
         UK
     .govuk-radios__item
       %input#registration-country-2.govuk-radios__input{name: 'registration-country',
                                                         type: 'radio',
                                                         value: 'Non-UK',
-                                                        checked: session.dig(:vehicle_details, 'country') == 'Non-UK'}
+                                                        checked: session.dig(:vehicle_details, 'country') == 'Non-UK' || session.dig(:vehicle_details, 'possible_fraud') == true}
       %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
         Non-UK

--- a/spec/requests/payments_controller/create_spec.rb
+++ b/spec/requests/payments_controller/create_spec.rb
@@ -14,9 +14,12 @@ RSpec.describe 'PaymentsController - POST #create', type: :request do
 
   before do
     add_to_session(
-      vrn: vrn, country: 'UK',
-      la_id: zone_id, la_name: 'Leeds',
-      dates: dates, total_charge: charge
+      vrn: vrn,
+      country: 'UK',
+      la_id: zone_id,
+      la_name: 'Leeds',
+      dates: dates,
+      total_charge: charge
     )
   end
 

--- a/spec/services/session_manipulation/clear_session_details_spec.rb
+++ b/spec/services/session_manipulation/clear_session_details_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SessionManipulation::ClearSessionDetails do
-  subject(:service) { described_class.call(session: session, key: 7) }
+  subject(:service) { described_class.call(session: session, key: 8) }
 
   let(:session) { { vehicle_details: details } }
   let(:details) do


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2860?focusedCommentId=220422 Fix for AC3

## Description
Remember country selection in session

## How Has This Been Tested?
Manually, test updated

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.
