### PR TITLE
[CAZ-2846] Fix datepicker on Safari

### DIFF
--- a/app/javascript/src/compatibilityHelpers.js
+++ b/app/javascript/src/compatibilityHelpers.js
@@ -96,3 +96,19 @@ export const addPrecedingZero = (value) => ("0" + value).slice(-2);
  * @return {Date} = date in local timezone
  */
 export const convertUTCToLocal = (date) => new Date(date.setHours(0, 0, 0, 0));
+
+const isSafari =
+  /constructor/i.test(window.HTMLElement) ||
+  (function (p) {
+    return p.toString() === "[object SafariRemoteNotification]";
+  })(
+    !window["safari"] ||
+      (typeof safari !== "undefined" && safari.pushNotification)
+  );
+
+export const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+
+/**
+ * Always add preceding zero if browser is unsupported
+ */
+export const addZero = isIE11 || isSafari;


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2846
## Description
<!--- Describe your changes in detail -->
Safari (as well as IE11) is unable to parse date in `YYYY-MM-DD` format without preceding zeros, eg. `2020-6-1`. This caused all days to be clickable. Added checking if the browser is Safari and adding zeros if needed

Expected behavior: only available days are highlighted
![image](https://user-images.githubusercontent.com/5519481/85411940-4ca07880-b569-11ea-8d60-1c9102d97d90.png)

Incorrect behavior: all days are available
![image](https://user-images.githubusercontent.com/5519481/85412050-7063be80-b569-11ea-85a5-6a4edc7f0f7d.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
