### PR TITLE
[CAZB-1944] Expect VRNs without leading zeros in the VRN form

### DIFF
--- a/app/models/vrn_form.rb
+++ b/app/models/vrn_form.rb
@@ -3,7 +3,7 @@
 ##
 # This class is used to validate user data filled in +app/views/vehicles/enter_details.html.haml+.
 #
-class VrnForm
+class VrnForm # rubocop:disable Metrics/ClassLength
   include ActiveModel::Validations
   include Rails.application.routes.url_helpers
 
@@ -22,6 +22,7 @@ class VrnForm
     minimum: 2, too_short: I18n.t('vrn_form.vrn_too_short'),
     maximum: 7, too_long: I18n.t('vrn_form.vrn_too_long')
   }, if: -> { uk? }
+
   # Checks if VRN is in valid format when vehicle is registered in the UK
   validate :vrn_uk_format, if: -> { uk? }
 
@@ -72,7 +73,12 @@ class VrnForm
   def match_uk_format?
     FORMAT_REGEXPS.any? do |reg|
       reg.match(vrn).present?
-    end
+    end && no_leading_zeros?
+  end
+
+  # Checks if VRN starts with '0'
+  def no_leading_zeros?
+    !vrn.starts_with?('0')
   end
 
   # Check if VRN is DVLA registered
@@ -145,6 +151,10 @@ class VrnForm
     /^[A-Z]{3}[0-9]{2}[A-Z]$/, # AAA99A
     /^[0-9]{3}[A-Z]{3}$/, # 999AAA
     /^[A-Z]{2}[0-9]{4}$/, # AA9999
-    /^[0-9]{4}[A-Z]{2}$/ # 9999AA
+    /^[0-9]{4}[A-Z]{2}$/, # 9999AA
+
+    # The following regex is technically not valid, but is considered as valid
+    # due to the requirement which forces users not to include leading zeros.
+    /^[A-Z]{2,3}$/ # AA, AAA
   ].freeze
 end

--- a/spec/models/vrn_form_spec.rb
+++ b/spec/models/vrn_form_spec.rb
@@ -78,6 +78,14 @@ describe VrnForm, type: :model do
       it_behaves_like 'an invalid vrn input', I18n.t('vrn_form.vrn_invalid')
     end
 
+    context 'when VRN starts with 0' do
+      let(:vrn) { '00SGL6' }
+
+      it { is_expected.not_to be_valid }
+
+      it_behaves_like 'an invalid vrn input', I18n.t('vrn_form.vrn_invalid')
+    end
+
     context 'when country in Non-UK' do
       let(:country) { 'Non-UK' }
 
@@ -110,25 +118,19 @@ describe VrnForm, type: :model do
 
         it { is_expected.to be_valid }
       end
+
+      context 'when vrn starts with 0' do
+        let(:vrn) { '00SGL6' }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 
   describe 'VRN formats' do
     describe 'invalid formats' do
-      context 'when VRN is in format AA' do
-        let(:vrn) { 'AB' }
-
-        it { is_expected.not_to be_valid }
-      end
-
       context 'when VRN is in format 99' do
         let(:vrn) { '45' }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context 'when VRN is in format AAA' do
-        let(:vrn) { 'ABG' }
 
         it { is_expected.not_to be_valid }
       end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA Card: https://eaflood.atlassian.net/browse/CAZB-1944

## Description
<!--- Describe your changes in detail -->
* When provided VRN begins with `0` and is marked as the UK, the validation is going to fail due to the wrong format.
* There are possible 2-characters formats like `9A`. Considering the card requirements it should be possible now to pass a single character VRNs for cases like `0G` but after consultation, it was decided that minimal length of VRN should remain 2.
* Updated specs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually.

## Screenshots (if appropriate):
![Screenshot 2020-07-01 at 11 43 29](https://user-images.githubusercontent.com/4506633/86229525-204fb200-bb90-11ea-944a-2eca6ed73cdb.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
