### PR TITLE
[CAZB-2194] Use DVLA_CONTACT_URL on "Your vehicle is UK registered" page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ CLOUDFRONT_ENDPOINT=
 # Google Tag Manager configuration
 GTM_ID=
 GTM_URL_OVERRIDES=
+
+# DVLA contact url
+DVLA_CONTACT_URL=

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,4 +43,9 @@ module ApplicationHelper
   def page_title(title_text)
     content_for(:title, "#{title_text} | #{service_name}")
   end
+
+  # Return link to proper DVLA contact form from env variables
+  def link_to_dvla_contact_form
+    link_to 'DVLA', ENV.fetch('DVLA_CONTACT_URL', 'https://contact-preprod.dvla.gov.uk/'), id: 'dvla-link'
+  end
 end

--- a/app/views/vehicles/uk_registered_details.html.haml
+++ b/app/views/vehicles/uk_registered_details.html.haml
@@ -18,9 +18,7 @@
         %br
         If your vehicle is registered outside the UK, contact
         = succeed '.' do
-          = link_to('DVLA',
-                    'https://www.gov.uk/contact-the-dvla',
-                    id: 'dvla-link')
+          = link_to_dvla_contact_form
         %br
         If the details displayed are correct, confirm to continue.
 


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZB-2194

## Description
Use url to DVLA contact form from env variable

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
