### PR TITLE
[CAZB-2200] Back button flow for unrecognised vehicle

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -102,6 +102,8 @@ class ChargesController < ApplicationController
   def local_authority_return_path # rubocop:disable Metrics/MethodLength
     if vehicle_details('undetermined')
       not_determined_vehicles_path
+    elsif vehicle_details('unrecognised') # when vehicle is non-dvla UK vehicle
+      choose_type_non_dvla_vehicles_path
     elsif vehicle_details('incorrect')
       incorrect_details_vehicles_path
     elsif vehicle_details('possible_fraud')
@@ -109,7 +111,7 @@ class ChargesController < ApplicationController
     elsif vehicle_details('country') == 'UK'
       details_vehicles_path
     else
-      choose_type_non_dvla_vehicles_path
+      choose_type_non_dvla_vehicles_path # when vehicle is non-UK vehicle
     end
   end
 

--- a/features/charges.feature
+++ b/features/charges.feature
@@ -34,6 +34,14 @@ Feature: Charges
     Then I press "Back" link
       And I should be on the vehicle details page
 
+  Scenario: User wants to return to type selection when his vehicle is UK and not recognised
+    Given I am on the choose type page for UK vehicle
+    Then I choose Car type
+      And I press the Confirm
+      And I should be on the local authorities page
+    Then I press "Back" link
+      And I should be on the choose type page
+
   Scenario: User selects LA to pay for
     Given My vehicle is not compliant
       And I am on the select local authority page

--- a/features/step_definitions/non_uk_vehicles_steps.rb
+++ b/features/step_definitions/non_uk_vehicles_steps.rb
@@ -5,6 +5,11 @@ Given('I am on the choose type page for non-UK vehicle') do
   visit choose_type_non_dvla_vehicles_path
 end
 
+Given('I am on the choose type page for UK vehicle') do
+  add_unrecognised_uk_vehicle_to_session
+  visit choose_type_non_dvla_vehicles_path
+end
+
 Then('I choose Car type') do
   choose('Car')
   mock_non_dvla_response

--- a/features/support/session_helper.rb
+++ b/features/support/session_helper.rb
@@ -9,6 +9,10 @@ module SessionHelper
     page.set_rack_session(vehicle_details: { vrn: vrn, country: 'Non-UK' })
   end
 
+  def add_unrecognised_uk_vehicle_to_session
+    page.set_rack_session(vehicle_details: { vrn: vrn, country: 'UK', unrecognised: true })
+  end
+
   def add_vrn_country_la_to_session
     page.set_rack_session(vehicle_details: compliance_details)
   end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2200

## Description
<!--- Describe your changes in detail -->
* Added `if` statement for scenario when vehicle is vehicle is UK based but not found in the DVLA - back button then follows back to the vehicle type selection page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and cucumber.

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
