### PR TITLE
[NON-JIRA] set second week to false on first week page

### DIFF
--- a/app/controllers/dates_controller.rb
+++ b/app/controllers/dates_controller.rb
@@ -216,6 +216,7 @@ class DatesController < ApplicationController # rubocop:disable Metrics/ClassLen
                        session_date: week_start_days.first,
                        back_button_date: back_button_week_dates.first)
 
+    SessionManipulation::SetSelectedWeek.call(session: session, second_week_selected: false)
     @return_path = select_weekly_date_return_path
     handle_select_weekly_date
   end
@@ -263,7 +264,6 @@ class DatesController < ApplicationController # rubocop:disable Metrics/ClassLen
     service = Dates::ValidateSelectedWeeklyDate.new(params: params,
                                                     charge_start_date: @charge_start_date,
                                                     session: session)
-
     if service.valid? && check_already_paid_weekly([service.start_date])
       Dates::AssignBackButtonDate.call(session: session)
       service.add_dates_to_session


### PR DESCRIPTION
Adding this statement setting `second_week_selected` on the first date selection page prevents a scenario where you:
1. Select a start date
2. Go to the review page
3. Click back
4. Click continue once again
5. Are shown an error where you have selected dates previously selected

I think the new back link work means for some reason this isn't getting set elsewhere and thus not triggering validation, but I'm not sure why. Possibly something to investigate further next sprint.