### PR TITLE
[CAZB-2826] Use become_compliant_url as dynamic_compliance_url

### DIFF
--- a/additional_url.yml
+++ b/additional_url.yml
@@ -6,6 +6,3 @@ leeds:
 birmingham:
   fleet: 'https://businessbreathes.co.uk/fleet-operator'
   non_fleet: 'https://www.brumbreathes.co.uk/info/6/upgrading-car/5/upgrading-car-1'
-bath:
-  fleet: 'https://www.bathnes.gov.uk/bath-breathes-2021-overview/support'
-  non_fleet: 'https://www.bathnes.gov.uk/bath-breathes-2021-overview/support'

--- a/app/models/compliance_details.rb
+++ b/app/models/compliance_details.rb
@@ -67,9 +67,16 @@ class ComplianceDetails
     url(:public_transport_options)
   end
 
-  # Returns "get support" link based on conditions
+  # Returns compliance url based or additional_compliance_url or compliance_url
   def dynamic_compliance_url
+    additional_compliance_url || compliance_url
+  end
+
+  # Returns compliance url from additlan_url.yml
+  def additional_compliance_url
     zone_links = additional_urls_file[zone_name.downcase]
+    return if zone_links.blank?
+
     if (leeds_taxi && zone_name == 'Leeds') || (car? && zone_name == 'Birmingham')
       return zone_links['non_fleet']
     end

--- a/spec/models/compliance_details_spec.rb
+++ b/spec/models/compliance_details_spec.rb
@@ -82,11 +82,11 @@ describe ComplianceDetails, type: :model do
         end
       end
 
-      describe 'dynamic_compliance_url' do
-        describe 'Leeds' do
+      describe '.dynamic_compliance_url' do
+        describe 'when additional_compliance_url is present' do
           let(:leeds_urls) { YAML.load_file('additional_url.yml')['leeds'] }
 
-          it 'returns leeds fleet url' do
+          it 'returns additional_compliance_url for leeds' do
             expect(details.dynamic_compliance_url).to eq(leeds_urls['fleet'])
           end
 
@@ -94,7 +94,33 @@ describe ComplianceDetails, type: :model do
             before { vehicle_details.merge!('leeds_taxi' => true) }
 
             it 'returns leeds non fleet url' do
-              expect(details.dynamic_compliance_url).to eq(leeds_urls['non_fleet'])
+              expect(details.additional_compliance_url).to eq(leeds_urls['non_fleet'])
+            end
+          end
+        end
+
+        describe 'when additional_compliance_url is not present' do
+          let(:name) { 'Bath' }
+
+          it 'returns compliance_url' do
+            expect(details.dynamic_compliance_url).to eq(details.compliance_url)
+          end
+        end
+      end
+
+      describe 'additional_compliance_url' do
+        describe 'Leeds' do
+          let(:leeds_urls) { YAML.load_file('additional_url.yml')['leeds'] }
+
+          it 'returns leeds fleet url' do
+            expect(details.additional_compliance_url).to eq(leeds_urls['fleet'])
+          end
+
+          describe 'taxi' do
+            before { vehicle_details.merge!('leeds_taxi' => true) }
+
+            it 'returns leeds non fleet url' do
+              expect(details.additional_compliance_url).to eq(leeds_urls['non_fleet'])
             end
           end
         end
@@ -104,14 +130,14 @@ describe ComplianceDetails, type: :model do
           let(:birmingham_urls) { YAML.load_file('additional_url.yml')['birmingham'] }
 
           it 'returns birmingham fleet url' do
-            expect(details.dynamic_compliance_url).to eq(birmingham_urls['fleet'])
+            expect(details.additional_compliance_url).to eq(birmingham_urls['fleet'])
           end
 
           describe 'car' do
             let(:type) { 'car' }
 
             it 'returns birmingham non_fleet url' do
-              expect(details.dynamic_compliance_url).to eq(birmingham_urls['non_fleet'])
+              expect(details.additional_compliance_url).to eq(birmingham_urls['non_fleet'])
             end
           end
 
@@ -119,8 +145,17 @@ describe ComplianceDetails, type: :model do
             let(:type) { nil }
 
             it 'returns birmingham fleet url' do
-              expect(details.dynamic_compliance_url).to eq(birmingham_urls['fleet'])
+              expect(details.additional_compliance_url).to eq(birmingham_urls['fleet'])
             end
+          end
+        end
+
+        describe 'Bath' do
+          let(:name) { 'Bath' }
+          let(:bath_urls) { YAML.load_file('additional_url.yml')['bath'] }
+
+          it 'returns nil' do
+            expect(details.additional_compliance_url).to be_nil
           end
         end
       end

--- a/spec/requests/dates_controller/daily_charges_spec.rb
+++ b/spec/requests/dates_controller/daily_charges_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'DatesController - GET #daily_charge', type: :request do
                     exemption_or_discount_url: url,
                     compliance_url: url,
                     main_info_url: url,
+                    additional_compliance_url: url,
                     dynamic_compliance_url: url,
                     global_exemption_guidance_url: url)
   end

--- a/spec/requests/dates_controller/weekly_charges_spec.rb
+++ b/spec/requests/dates_controller/weekly_charges_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'DatesController - GET #weekly_charge', type: :request do
                     charge: 50,
                     exemption_or_discount_url: url,
                     compliance_url: url,
+                    additional_compliance_url: url,
                     dynamic_compliance_url: url,
                     global_exemption_guidance_url: url)
   end

--- a/spec/requests/payments_controller/success_spec.rb
+++ b/spec/requests/payments_controller/success_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'PaymentsController - GET #success', type: :request do
       .to receive(:new)
       .and_return(instance_double(ComplianceDetails,
                                   public_transport_options_url: url,
+                                  additional_compliance_url: url,
                                   dynamic_compliance_url: url))
     subject
   end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira card: https://eaflood.atlassian.net/browse/CAZB-2826
## Description
<!--- Describe your changes in detail -->
When url is not found in `additonal_url.yml` we should use `become_compliant_url`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added rspec 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
