### PR TITLE
[CAZB-2978] IOD - typo on Privacy notice

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -7,7 +7,7 @@
           %li.govuk-footer__inline-list-item
             = link_to('Cookies', cookies_path, class: 'govuk-footer__link')
           %li.govuk-footer__inline-list-item
-            = link_to('Privacy Notice', privacy_notice_path, class: 'govuk-footer__link')
+            = link_to('Privacy notice', privacy_notice_path, class: 'govuk-footer__link')
           %li.govuk-footer__inline-list-item
             = link_to('Accessibility statement', accessibility_statement_path, class: 'govuk-footer__link')
 

--- a/app/views/static_pages/privacy_notice.html.haml
+++ b/app/views/static_pages/privacy_notice.html.haml
@@ -202,7 +202,7 @@
         = link_to('DfT', dtf_link, id: 'dtf-link')
 
       %p
-        If you want to know about the Privacy Notice specific to DVLA or the CAZ and Local Authority you are using, please use these links:
+        If you want to know about the privacy notice specific to DVLA or the CAZ and Local Authority you are using, please use these links:
       %p
         = link_to('DVLA',
                   'https://www.gov.uk/government/publications/dvla-privacy-policy/dvla-privacy-policy',

--- a/features/static_pages.feature
+++ b/features/static_pages.feature
@@ -16,7 +16,7 @@ Feature: Static Pages
 
   Scenario: User sees privacy notice page
     Given I am on the home page
-    When I press "Privacy Notice" footer link
+    When I press "Privacy notice" footer link
     Then I should see "Drive in a Clean Air Zone"
       And I should see "Check if you’ll be charged to drive in a Clean Air Zone "
 


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZB-2978

## Description
Change Privacy notice in footer and in text occurence

## How Has This Been Tested?
Manually, existing test fixed

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.
