### PR TITLE
[CAZB-2893] Fix back button navigation after successful payment

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -23,7 +23,7 @@ class VehiclesController < ApplicationController # rubocop:disable Metrics/Class
   #
   def enter_details
     @errors = {}
-    clear_inputs_if_coming_from_successful_payment
+    hide_inputs_if_coming_from_successful_payment
   end
 
   ##
@@ -314,10 +314,10 @@ class VehiclesController < ApplicationController # rubocop:disable Metrics/Class
     session['vehicle_details']['undetermined'].present?
   end
 
-  # Clear VRN and country when paying for another vehicle from the success payment page
-  def clear_inputs_if_coming_from_successful_payment
+  # Hide VRN and country when paying for another vehicle from the success payment page
+  def hide_inputs_if_coming_from_successful_payment
     return unless request.referer&.include?(success_payments_path)
 
-    SessionManipulation::ClearSessionDetails.call(session: session, key: 1)
+    @hide_inputs = true
   end
 end

--- a/app/views/vehicles/country_input/_common.html.haml
+++ b/app/views/vehicles/country_input/_common.html.haml
@@ -1,3 +1,6 @@
+- uk_checked = session.dig(:vehicle_details, 'country') == 'UK' && session.dig(:vehicle_details, 'possible_fraud') != true
+- non_uk_checked = session.dig(:vehicle_details, 'country') == 'Non-UK' || session.dig(:vehicle_details, 'possible_fraud') == true
+
 .govuk-radios.govuk-radios--inline
   %fieldset.govuk-fieldset
     %legend.govuk-legend
@@ -5,13 +8,13 @@
         %input#registration-country-1.govuk-radios__input{name: 'registration-country',
                                                           type: 'radio',
                                                           value: 'UK',
-                                                          checked: session.dig(:vehicle_details, 'country') == 'UK' && session.dig(:vehicle_details, 'possible_fraud') != true}
+                                                          checked: (uk_checked unless @hide_inputs)}
         %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
           UK
       .govuk-radios__item
         %input#registration-country-2.govuk-radios__input{name: 'registration-country',
                                                           type: 'radio',
                                                           value: 'Non-UK',
-                                                          checked: session.dig(:vehicle_details, 'country') == 'Non-UK' || session.dig(:vehicle_details, 'possible_fraud') == true}
+                                                          checked: (non_uk_checked unless @hide_inputs)}
         %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
           Non-UK

--- a/app/views/vehicles/vrn_input/_normal.html.haml
+++ b/app/views/vehicles/vrn_input/_normal.html.haml
@@ -7,4 +7,4 @@
                                    name: 'vrn',
                                    type: 'text',
                                    maxlength: 15,
-                                   value: session.dig(:vehicle_details, 'vrn') || params[:vrn]}
+                                   value: (session.dig(:vehicle_details, 'vrn') || params[:vrn] unless @hide_inputs)}

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -36,3 +36,9 @@ Feature: Payments
       And I'm getting redirected from GOV.UK Pay
     Then I press "return to the start page" link
       And I should be on the start page
+
+  Scenario: User wants to pay for another vehicle after successful payment process
+    Given I have finished the payment successfully
+      And I'm getting redirected from GOV.UK Pay
+    Then I press "Pay for another vehicle" link
+      And The LA inputs should not be filled

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -40,5 +40,5 @@ Feature: Payments
   Scenario: User wants to pay for another vehicle after successful payment process
     Given I have finished the payment successfully
       And I'm getting redirected from GOV.UK Pay
-    Then I press "Pay for another vehicle" link
+    Then I press 'Pay for another vehicle' link
       And The LA inputs should not be filled

--- a/features/step_definitions/charges_steps.rb
+++ b/features/step_definitions/charges_steps.rb
@@ -174,6 +174,12 @@ Given('I am on the pick weekly dates page with no passes available to buy') do
   visit select_weekly_date_dates_path
 end
 
+And('The LA inputs should not be filled') do
+  expect(find('input#vrn').value).to be_nil
+  expect(find('input#registration-country-1')).not_to be_checked
+  expect(find('input#registration-country-2')).not_to be_checked
+end
+
 private
 
 def paid_period


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2893

## Description
<!--- Describe your changes in detail -->
After clicking `Pay for another vehicle`:
Instead of clearing the VRN from the session, it's preserved in the session and not displayed in the input. Thanks to this, after clicking `Pay for another CAZ` VRN doesn't have to be entered again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
