### PR TITLE
[CAZB-2577] Improve input handling for Pay for another vehicle link

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -276,6 +276,7 @@ class VehiclesController < ApplicationController # rubocop:disable Metrics/Class
 
   # Renders enter_details page and log errors
   def rerender_enter_details(form)
+    @hide_session_values = true
     @errors = form.errors.messages
     render enter_details_vehicles_path
   end
@@ -318,6 +319,6 @@ class VehiclesController < ApplicationController # rubocop:disable Metrics/Class
   def hide_inputs_if_coming_from_successful_payment
     return unless request.referer&.include?(success_payments_path)
 
-    @hide_inputs = true
+    @hide_session_values = true
   end
 end

--- a/app/views/vehicles/country_input/_common.html.haml
+++ b/app/views/vehicles/country_input/_common.html.haml
@@ -1,5 +1,10 @@
-- uk_checked = session.dig(:vehicle_details, 'country') == 'UK' && session.dig(:vehicle_details, 'possible_fraud') != true
-- non_uk_checked = session.dig(:vehicle_details, 'country') == 'Non-UK' || session.dig(:vehicle_details, 'possible_fraud') == true
+- possible_fraud = session.dig(:vehicle_details, 'possible_fraud')
+- session_country = session.dig(:vehicle_details, 'country')
+
+- uk_checked_session = session_country == 'UK' && possible_fraud != true && !@hide_session_values
+- uk_checked_params = params['registration-country'] == 'UK'
+- non_uk_checked_session = (session_country == 'Non-UK' || possible_fraud == true) && !@hide_session_values
+- non_uk_checked_params = params['registration-country'] == 'Non-UK'
 
 .govuk-radios.govuk-radios--inline
   %fieldset.govuk-fieldset
@@ -8,13 +13,13 @@
         %input#registration-country-1.govuk-radios__input{name: 'registration-country',
                                                           type: 'radio',
                                                           value: 'UK',
-                                                          checked: (uk_checked unless @hide_inputs)}
+                                                          checked: uk_checked_session || uk_checked_params}
         %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
           UK
       .govuk-radios__item
         %input#registration-country-2.govuk-radios__input{name: 'registration-country',
                                                           type: 'radio',
                                                           value: 'Non-UK',
-                                                          checked: (non_uk_checked unless @hide_inputs)}
+                                                          checked: non_uk_checked_session || non_uk_checked_params}
         %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
           Non-UK

--- a/app/views/vehicles/vrn_input/_normal.html.haml
+++ b/app/views/vehicles/vrn_input/_normal.html.haml
@@ -7,4 +7,4 @@
                                    name: 'vrn',
                                    type: 'text',
                                    maxlength: 15,
-                                   value: (session.dig(:vehicle_details, 'vrn') && !@hide_session_values) || params[:vrn]}
+                                   value: (!@hide_session_values && session.dig(:vehicle_details, 'vrn')) || params[:vrn]}

--- a/app/views/vehicles/vrn_input/_normal.html.haml
+++ b/app/views/vehicles/vrn_input/_normal.html.haml
@@ -7,4 +7,4 @@
                                    name: 'vrn',
                                    type: 'text',
                                    maxlength: 15,
-                                   value: (session.dig(:vehicle_details, 'vrn') || params[:vrn] unless @hide_inputs)}
+                                   value: (session.dig(:vehicle_details, 'vrn') && !@hide_session_values) || params[:vrn]}

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -42,3 +42,5 @@ Feature: Payments
       And I'm getting redirected from GOV.UK Pay
     Then I press 'Pay for another vehicle' link
       And The LA inputs should not be filled
+    Then I press the Continue
+      And The LA inputs should not be filled

--- a/features/step_definitions/charges_steps.rb
+++ b/features/step_definitions/charges_steps.rb
@@ -175,7 +175,7 @@ Given('I am on the pick weekly dates page with no passes available to buy') do
 end
 
 And('The LA inputs should not be filled') do
-  expect(find('input#vrn').value).to be_nil
+  expect(find('input#vrn').value.blank?).to eq(true)
   expect(find('input#registration-country-1')).not_to be_checked
   expect(find('input#registration-country-2')).not_to be_checked
 end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2577

## Description
<!--- Describe your changes in detail -->
The case featured in bug report video (https://eaflood.atlassian.net/browse/CAZB-2578?focusedCommentId=229926) was already fixed, but after clicking Continue button with empty form, old values reappeared. Added variable to hide session values on rerender and use only values from `params`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, cucumber

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
