### PR TITLE
[CAZB-2893] Fix Pay for another vehicle back button in IE11

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -67,7 +67,6 @@ class PaymentsController < ApplicationController
   #
   def success
     @payment_details = PaymentDetails.new(session[:vehicle_details])
-    clear_payment_in_session
   end
 
   ##

--- a/spec/requests/payments_controller/success_spec.rb
+++ b/spec/requests/payments_controller/success_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe 'PaymentsController - GET #success', type: :request do
     expect(response).to have_http_status(:success)
   end
 
-  it 'clears payment details in session' do
-    expect(session[:vehicle_details]['payment_id']).to be_nil
-  end
-
   it 'does not clear other details in session' do
     expect(session[:vehicle_details]['vrn']).to eq(vrn)
   end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2893?focusedCommentId=240615

## Description
<!--- Describe your changes in detail -->
`Payment successful` page for some reason is not cached in IE11. Refreshing or nagivating to this page by clicking `Back` redirects to `/vehicles/enter_details` (since `payment_id` was not found in session anymore) and breaks browser history

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
