### PR TITLE
[CAZB-2893] Payment successful session handling fix for IE11

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -176,7 +176,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     session[:history][transaction_id][:second_week_start_date] = session[:second_week_start_date] || nil
   end
 
-  # backs up the session
+  # restores the session
   def restore_session
     # restore main session
     session[:vehicle_details] = session[:history][url_id][:vehicle_details]

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -24,9 +24,9 @@ class PaymentsController < ApplicationController
     payment = PaymentStatus.new(vehicle_details('payment_id'))
     save_payment_details(payment)
     if payment.success?
-      redirect_to success_payments_path
+      redirect_to success_payments_path(id: transaction_id)
     else
-      redirect_to failure_payments_path
+      redirect_to failure_payments_path(id: transaction_id)
     end
   end
 

--- a/spec/requests/payments_controller/index_spec.rb
+++ b/spec/requests/payments_controller/index_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'PaymentsController - GET #index', type: :request do
 
     context 'when payment status is SUCCESS' do
       it 'redirects to the success page' do
-        expect(response).to redirect_to(success_payments_path)
+        expect(response).to redirect_to(success_payments_path(id: session[:transaction_id]))
       end
 
       it 'sets user email in the session' do
@@ -46,7 +46,7 @@ RSpec.describe 'PaymentsController - GET #index', type: :request do
       let(:success) { false }
 
       it 'redirects to the failure page' do
-        expect(response).to redirect_to(failure_payments_path)
+        expect(response).to redirect_to(failure_payments_path(id: session[:transaction_id]))
       end
 
       it 'does set user email in the session' do


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2893

## Description
<!--- Describe your changes in detail -->
Govuk pay will now redirect to payment successful page with `id` query parameter. This allows `handle_history` to restore the session if new payment flow is started and user wants to come back to payment successful page

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on chrome and IE11, rspec updated

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
