### PR TITLE
[CAZB-4095] Safari browser the Continue button is overlapping on top of UK radio button in VRN entry page

### DIFF
--- a/app/views/vehicles/country_input/_common.html.haml
+++ b/app/views/vehicles/country_input/_common.html.haml
@@ -7,19 +7,17 @@
 - non_uk_checked_params = params['registration-country'] == 'Non-UK'
 
 .govuk-radios.govuk-radios--inline
-  %fieldset.govuk-fieldset
-    %legend.govuk-legend
-      .govuk-radios__item
-        %input#registration-country-1.govuk-radios__input{name: 'registration-country',
-                                                          type: 'radio',
-                                                          value: 'UK',
-                                                          checked: uk_checked_session || uk_checked_params}
-        %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
-          UK
-      .govuk-radios__item
-        %input#registration-country-2.govuk-radios__input{name: 'registration-country',
-                                                          type: 'radio',
-                                                          value: 'Non-UK',
-                                                          checked: non_uk_checked_session || non_uk_checked_params}
-        %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
-          Non-UK
+  .govuk-radios__item
+    %input#registration-country-1.govuk-radios__input{name: 'registration-country',
+                                                      type: 'radio',
+                                                      value: 'UK',
+                                                      checked: uk_checked_session || uk_checked_params}
+    %label.govuk-label.govuk-radios__label{for: 'registration-country-1'}
+      UK
+  .govuk-radios__item
+    %input#registration-country-2.govuk-radios__input{name: 'registration-country',
+                                                      type: 'radio',
+                                                      value: 'Non-UK',
+                                                      checked: non_uk_checked_session || non_uk_checked_params}
+    %label.govuk-label.govuk-radios__label{for: 'registration-country-2'}
+      Non-UK


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZB-4095

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Safari: 
![image](https://user-images.githubusercontent.com/998642/110336024-c0fe4780-8024-11eb-9e34-222f3b93b518.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
