### PR TITLE
[CAZB-4771] Remove memorization for `ComplianceCheckerApi.clean_air_zones`

### DIFF
--- a/app/models/vehicle_details.rb
+++ b/app/models/vehicle_details.rb
@@ -125,6 +125,6 @@ class VehicleDetails
   # and returns the list of available Clean Air Zones.
   #
   def caz_ids
-    @caz_ids ||= ComplianceCheckerApi.clean_air_zones.map { |e| e['cleanAirZoneId'] }
+    @caz_ids = ComplianceCheckerApi.clean_air_zones.map { |e| e['cleanAirZoneId'] }
   end
 end

--- a/app/services/caz_data_provider.rb
+++ b/app/services/caz_data_provider.rb
@@ -25,7 +25,7 @@ class CazDataProvider
 
     # Fetches clean air zones data
     def clean_air_zones
-      @clean_air_zones ||= ComplianceCheckerApi.clean_air_zones
+      @clean_air_zones = ComplianceCheckerApi.clean_air_zones
     end
 
     # Finds the expected clean air zone data based on provided zone id

--- a/app/services/chargeable_zones_service.rb
+++ b/app/services/chargeable_zones_service.rb
@@ -76,7 +76,7 @@ class ChargeableZonesService < BaseService
 
   # Calling API and returns the list of the available local authorities.
   def zone_data
-    @zone_data ||= ComplianceCheckerApi.clean_air_zones
+    @zone_data = ComplianceCheckerApi.clean_air_zones
   end
 
   # Select chargeable zones and returns ids

--- a/spec/services/chargeable_zones_service_spec.rb
+++ b/spec/services/chargeable_zones_service_spec.rb
@@ -103,13 +103,17 @@ describe ChargeableZonesService do
       before do
         mock_vehicle_compliance
         mock_unrecognised_compliance
+        service_call
       end
 
       it_behaves_like 'a chargeable zones service'
 
       it 'calls ComplianceCheckerApi.unrecognised_compliance with the right params' do
-        service_call
         expect(ComplianceCheckerApi).to have_received(:unrecognised_compliance).with(type, mocked_zone_ids)
+      end
+
+      it 'calls ComplianceCheckerApi.clean_air_zones' do
+        expect(ComplianceCheckerApi).to have_received(:clean_air_zones).exactly(3).times
       end
     end
   end

--- a/spec/support/shared_examples/chareable_zones_service.rb
+++ b/spec/support/shared_examples/chareable_zones_service.rb
@@ -12,9 +12,4 @@ RSpec.shared_examples 'a chargeable zones service' do |size = 2|
   it 'sets name in Caz objects' do
     expect(service_call.map(&:name)).to all(be_a(String))
   end
-
-  it 'calls ComplianceCheckerApi.clean_air_zones' do
-    service_call
-    expect(ComplianceCheckerApi).to have_received(:clean_air_zones)
-  end
 end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-4771
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
